### PR TITLE
Visual Studio Code: POC to open VSC on the current file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import * as notification from "./notification";
 import * as analytics from "./analytics";
 import * as search from "./search";
 import * as ethicalads from "./ethicalads";
+import * as visualstudiocode from "./visual-studio-code";
 import { domReady, isReadTheDocsEmbedPresent } from "./utils";
 
 export function setup() {
@@ -23,6 +24,7 @@ export function setup() {
         if (!IS_PRODUCTION) {
           addons.push(search.SearchAddon);
           addons.push(ethicalads.EthicalAdsAddon);
+          addons.push(visualstudiocode.VisualStudioCodeAddon);
         }
 
         for (const addon of addons) {

--- a/src/visual-studio-code.js
+++ b/src/visual-studio-code.js
@@ -1,0 +1,40 @@
+import { AddonBase } from "./utils";
+
+
+/**
+ * VisualStudioCode addon
+ *
+ * Open https://github.dev/ (Visual Studio Code) on the specific file for the current page.
+ *
+ * @param {Object} config - Addon configuration object
+ */
+export class VisualStudioCodeAddon extends AddonBase {
+  constructor(config) {
+    super();
+    this.config = config;
+
+    document.addEventListener("keydown", this._handleHotKey);
+  }
+
+  openVisualStudioCode() {
+    // TODO: find a way to get the GitHub URL from the API that matches the current page.
+    // Note it could be an ``.md``, ``.rst`` or anything.
+    // I know we have some Python code already written for this, but I think it's not reliable
+    // and it may need som modifications / a complete refactor.
+    //
+    // window.location.href = this.config.addons.visualstudiocode.url;
+    window.location.href = "https://github.dev/readthedocs/test-builds/blob/main/README.rst";
+  }
+
+  _handleHotKey = (e) => {
+    e.preventDefault();
+    // TODO: make this check a helper in ``src/utils.js``
+    if (e.keyCode === 190 && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && document.activeElement.tagName == "BODY") {
+      this.openVisualStudioCode();
+    }
+  };
+
+  static isEnabled(config) {
+    return config.addons && config.addons.visualstudiocode.enabled;
+  }
+}


### PR DESCRIPTION
This a small POC to open VSC when hitting `.` on a documentation page. We still need to find out how to get the URL we want to open in a reliable way.

Closes #82