### PR TITLE
Enable search + flyout and don't break

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export function setup() {
           // Addons that are only available on development
           addons.push(ethicalads.EthicalAdsAddon);
           // NOTE: Disabling search for now because it's incompatible with Flyout
-          // addons.push(search.SearchAddon);
+          addons.push(search.SearchAddon);
         }
 
         for (const addon of addons) {

--- a/src/new-flyout.js
+++ b/src/new-flyout.js
@@ -234,7 +234,11 @@ export class FlyoutAddon extends AddonBase {
     let elems = document.querySelectorAll("readthedocs-flyout");
     if (!elems.length) {
       elems = [new FlyoutElement()];
-      render(elems[0], document.body);
+
+      // We cannot use `render(elems[0], document.body)` because there is a race conditions between all the addons.
+      // So, we append the web-component first and then request an update of it.
+      document.body.append(elems[0]);
+      elems[0].requestUpdate();
     }
 
     for (const elem of elems) {

--- a/src/notification.js
+++ b/src/notification.js
@@ -206,7 +206,8 @@ export class NotificationAddon extends AddonBase {
     let elems = document.querySelectorAll("readthedocs-notification");
     if (!elems.length) {
       elems = [new NotificationElement()];
-      render(elems[0], document.body);
+      document.body.append(elems[0]);
+      elems[0].requestUpdate();
     }
 
     for (const elem of elems) {

--- a/src/search.js
+++ b/src/search.js
@@ -537,7 +537,8 @@ export class SearchAddon extends AddonBase {
     let elems = document.querySelectorAll("readthedocs-search");
     if (!elems.length) {
       elems = [new SearchElement()];
-      render(elems[0], document.body);
+      document.body.append(elems[0]);
+      elems[0].requestUpdate();
     }
 
     for (const elem of elems) {


### PR DESCRIPTION
We had a problem when enabling multiple addons because the manipulation of the DOM in an async way. This commit uses a different pattern that solves this issue.

Closes #91