### PR TITLE
Remove check for "compiled assets up-to-date"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,11 @@ commands:
       - run: npm ci
       - run: npm run lint
   run-build:
-    description: "Ensure compiled assets are up to date and HTML is valid"
+    description: "Ensure assets compile properly"
     steps:
       - checkout
       - run: npm ci
       - run: npm run build
-      - run:
-          name: Ensure built assets are up to date
-          command: |
-            if [[ `git status dist/ --porcelain` ]]
-            then
-              echo "ERROR: assets are out of date. Make sure to run 'npm run build' on your branch."
-              git status dist/ --porcelain
-              exit 1
-            fi
 
 jobs:
   checks:


### PR DESCRIPTION
Do not check if the `dist/` compiled assets are up-to-date on CircleCI. This has been pretty annoying to work with.
Each time you add a commit, you have to re-compile the assets. Then if another PR is merged, you have to update your branch and re-compile the assets.

Now, since we are adding a release process that explicity re-compile the assets before doing the release, compiling them on each PR doesn't make sense anymore.

We will be always using the compiled assets from GitHub tags now when deploying.