### PR TITLE
Set up pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,24 @@ repos:
     hooks:
       - id: prettier
         args: ["--write", "src/**", "*.js", "*.json"]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-vcs-permalinks
+      - id: check-yaml
+      - id: destroyed-symlinks
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: .
+    rev: humitos/pre-commit-setup
+    hooks:
+      - id: check-build-assets

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: check-build-assets
+  name: ensure assets are bundled
+  description: Make sure that `npm run build` was ran before commiting.
+  language: script
+  types: [css, javascript, svg]
+  entry: check-build-assets.sh

--- a/check-build-assets.sh
+++ b/check-build-assets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+npm run build
+
+if [[ `git status dist/ --porcelain` ]]
+then
+    echo "ERROR: assets are out of date."
+    echo "Run 'git add dist/*' to stash the changes before commiting."
+    exit 1
+fi


### PR DESCRIPTION
This is the continuation of the work done in https://github.com/readthedocs/addons/pull/114 since we are not yet ready to remove the `dist/` folder from the repository.

`pre-commit` at least will make this process a little less tedious and automated 😉 . It calls `prettier` and also checks if the `dist/` folder is out of date. In that case, we just need to call `git add dist/` to add the new bundled files compiled by `pre-commit`.

Closes #114 