### PR TITLE
Alter the configuration around externals and default exports

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -23,7 +23,9 @@ export default {
     rollupAdapter(rollupLitCss()),
     pluginCommonjs({
       include: "node_modules/**",
-      requireReturnsDefault: "preferred",
+      esmExternals: true,
+      defaultIsModuleExports: true,
+      requireReturnsDefault: true,
     }),
   ],
 };


### PR DESCRIPTION
Preferred default export mode is not required anymore, and this plays
nicely with other TS libraries.

Refs #182