### PR TITLE
Changelog: fix inconsistencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,20 +3,21 @@ CHANGELOG
 
 .. The text for the changelog is manually generated for now.
 
-Version v0.9.2
+Version v0.9.3
 --------------
 
 :date: Jan 15, 2024
 
 * Security fix, more information in `GHSA-9v45-336h-5xw5 <https://github.com/readthedocs/addons/security/advisories/GHSA-9v45-336h-5xw5>`__.
+* Update all ``npm`` dependencies with with ``ncu -u``
 
-Version v0.9.1
+Version v0.9.2
 --------------
 
 :date: December 19, 2023
 
 * Don't show search input on flyout when search is disabled
-* Update all ``npm`` dependencies with
+* Update all ``npm`` dependencies with with ``ncu -u``
 
 Version v0.9.1
 --------------


### PR DESCRIPTION
I found that 0.9.1 was duplicated and created confusions.