### PR TITLE
ncu: reject `rollup/plugin-commonjs`

### DIFF
--- a/.github/workflows/ncu.yaml
+++ b/.github/workflows/ncu.yaml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Update packages
         # ``unfetch`` is rejected here because its latest version is not compatible with our project
-        run: ncu --upgrade --reject unfetch
+        # ``rollup/plugin-commonjs`` is rejected because >26 breaks the tests
+        run: ncu --upgrade --reject unfetch --reject rollup/plugin-commonjs
 
       - name: Install them and update "package-lock.json"
         run: npm install


### PR DESCRIPTION
Don't update `rollup/plugin-commonjs` for now until we figure it out how to solve the tests with the latest version.

Closes #425