### PR TITLE
Don't wrap the flyout header.

### DIFF
--- a/src/flyout.css
+++ b/src/flyout.css
@@ -55,7 +55,7 @@
 
 header {
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: row nowrap;
   justify-content: space-between;
   align-items: center;
   cursor: pointer;


### PR DESCRIPTION
This makes it so the version doesn't overflow as badly:

## Before
<img width="325" alt="Screenshot 2024-11-19 at 2 30 24 PM" src="https://github.com/user-attachments/assets/3abc274a-95a9-4711-a66b-4f7cf43b8e12">


## After 

<img width="323" alt="Screenshot 2024-11-19 at 2 30 12 PM" src="https://github.com/user-attachments/assets/7d6e129a-9d84-4ab8-977a-06fe0054ad51">
