### PR TITLE
Add `article` to the FALLBACK_DOCTOOL list

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -287,7 +287,7 @@ export class DocumentationTool {
     [DOCUSAURUS]: "article",
     [ANTORA]: "article",
     [JEKYLL]: "article",
-    [FALLBACK_DOCTOOL]: ["main", "div.body", "div.document", "body"],
+    [FALLBACK_DOCTOOL]: ["article", "main", "div.body", "div.document", "body"],
   };
 
   static DEFAULT_LINK_SELECTOR = {


### PR DESCRIPTION
It seems this is common enough in other doc tools,
I think we should probably include it in the default?

I hit this with markdoc, where `main` includes the sidebars and other non-primary content. 