### PR TITLE
Fix invalid syntax in readthedocs-addons.json

### DIFF
--- a/public/_/readthedocs-addons.json
+++ b/public/_/readthedocs-addons.json
@@ -124,7 +124,7 @@
     },
     "doc_diff": {
       "enabled": true,
-      "base_url": "http://localhost:8000/docdiff.changed.html",
+      "base_url": "http://localhost:8000/docdiff.changed.html"
     },
     "filetreediff": {
       "enabled": true,


### PR DESCRIPTION
This was breaking my local setup