### PR TITLE
Fix storing recent search when using keyboard

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -530,7 +530,7 @@ export class SearchElement extends LitElement {
       const selected = this.renderRoot.querySelector("a.hit.active");
       // if an item is selected, then redirect to its link
       if (selected !== null) {
-        window.location.href = selected.href;
+        selected.click();
       }
     }
 


### PR DESCRIPTION
Initially I implemented a custom event to achieve this, but in the end, simply using `click` event seemed like a much cleaner solution.

Closes #399 