### PR TITLE
Links preview: specify the `?selector=` attribute

### DIFF
--- a/src/linkpreviews.js
+++ b/src/linkpreviews.js
@@ -191,7 +191,7 @@ function setupTooltip(el, doctoolname, doctoolversion, selector) {
     }
 
     if (selector !== null) {
-      params["selector"] = selector;
+      params["maincontent"] = selector;
     }
 
     const api_url =

--- a/src/linkpreviews.js
+++ b/src/linkpreviews.js
@@ -21,7 +21,7 @@ const SHOW_TOOLTIP_DELAY = 300;
 const HIDE_TOOLTIP_DELAY = 300;
 const TOOLTIP_DATA_HREF = "data-linkpreview-href";
 
-function setupTooltip(el, doctoolname, doctoolversion) {
+function setupTooltip(el, doctoolname, doctoolversion, selector) {
   // Take the provided element and setup the listeners required to
   // make the linkpreviews work
 
@@ -190,6 +190,10 @@ function setupTooltip(el, doctoolname, doctoolversion) {
       params["doctoolversion"] = doctoolversion;
     }
 
+    if (selector !== null) {
+      params["selector"] = selector;
+    }
+
     const api_url =
       "/_/api/v3/embed/?" + new URLSearchParams(params).toString();
     return api_url;
@@ -241,7 +245,7 @@ export class LinkPreviewsAddon extends AddonBase {
           elementUrl.pathname.replace("/index.html");
         if (elementHostname === window.location.hostname && !pointToSamePage) {
           element.classList.add("link-preview");
-          setupTooltip(element, doctoolName, null);
+          setupTooltip(element, doctoolName, null, rootSelector);
         }
       } catch (error) {
         console.debug(

--- a/src/utils.js
+++ b/src/utils.js
@@ -284,7 +284,7 @@ export class DocumentationTool {
     [DOCSIFY]: "article#main",
     [ASCIIDOCTOR]: "div#content",
     [PELICAN]: "article",
-    [DOCUSAURUS]: "article",
+    [DOCUSAURUS]: "article div.markdown",
     [ANTORA]: "article",
     [JEKYLL]: "article",
     [FALLBACK_DOCTOOL]: ["article", "main", "div.body", "div.document", "body"],


### PR DESCRIPTION
Tell the EmbedAPI what's the selector for the main content of the page. This allows the backend to know exactly what content to return when the whole page has to be returned.

Requires https://github.com/readthedocs/readthedocs.org/pull/11812