### PR TITLE
EthicalAd: better ad position for Docsify

### DIFF
--- a/src/ethicalads.css
+++ b/src/ethicalads.css
@@ -242,3 +242,9 @@ div.ethical-footer {
   margin-left: 10% !important;
   margin-right: 10% !important;
 }
+
+/* Docsify */
+.ethical-docsify {
+  margin-left: 10% !important;
+  margin-right: 10% !important;
+}

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -139,6 +139,18 @@ export class EthicalAdsAddon extends AddonBase {
           placement.setAttribute("data-ea-style", "image");
           knownPlacementFound = true;
         }
+      } else if (docTool.isDocsify()) {
+        selector = "main > aside > div.sidebar-nav";
+        element = document.querySelector(selector);
+
+        if (this.elementAboveTheFold(element)) {
+          placement.classList.add("ethical-alabaster");
+          placement.classList.add("ethical-docsify");
+
+          placement.setAttribute("data-ea-type", "readthedocs-sidebar");
+          placement.setAttribute("data-ea-style", "image");
+          knownPlacementFound = true;
+        }
       }
 
       if (selector && knownPlacementFound) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -407,8 +407,19 @@ export class DocumentationTool {
       return MKDOCS;
     }
 
+    if (this.isDocsify()) {
+      return DOCSIFY;
+    }
+
     console.debug("We were not able to detect the documentation tool.");
     return null;
+  }
+
+  isDocsify() {
+    if (document.querySelectorAll("head > link[href*=docsify]").length) {
+      return true;
+    }
+    return false;
   }
 
   isSphinx() {


### PR DESCRIPTION
Show how simple is to add a better ad positioning for a documentation tool that we know.

1. Find the CSS selector that allows to detect the framework
2. Find the CSS selector for the ad position
3. Add small CSS for styling if required

![Screenshot_2024-12-12_12-12-47](https://github.com/user-attachments/assets/7b3dac1f-701f-4e55-83b4-13bb86e96690)


Related https://github.com/readthedocs/addons/pull/447