### PR TITLE
Add styles based on the documentation tool

### DIFF
--- a/src/flyout.js
+++ b/src/flyout.js
@@ -8,7 +8,15 @@ import { classMap } from "lit/directives/class-map.js";
 import { default as objectPath } from "object-path";
 
 import styleSheet from "./flyout.css";
-import { AddonBase, addUtmParameters, getLinkWithFilename } from "./utils";
+import styleMkDocsMaterial from "./flyout.mkdocs.material.css";
+import styleSphinxFuro from "./flyout.sphinx.furo.css";
+import {
+  AddonBase,
+  addUtmParameters,
+  getLinkWithFilename,
+  docTool,
+} from "./utils";
+import { SPHINX, MKDOCS_MATERIAL } from "./constants";
 import {
   EVENT_READTHEDOCS_SEARCH_SHOW,
   EVENT_READTHEDOCS_FLYOUT_HIDE,
@@ -386,6 +394,17 @@ export class FlyoutAddon extends AddonBase {
 
     for (const elem of elems) {
       elem.loadConfig(config);
+    }
+
+    this.addCustomStyle();
+  }
+
+  addCustomStyle() {
+    const doctool = docTool.documentationTool;
+    if (doctool === MKDOCS_MATERIAL) {
+      document.adoptedStyleSheets.push(styleMkDocsMaterial);
+    } else if (doctool == SPHINX && docTool.isSphinxFuroLikeTheme()) {
+      document.adoptedStyleSheets.push(styleSphinxFuro);
     }
   }
 }

--- a/src/flyout.mkdocs.material.css
+++ b/src/flyout.mkdocs.material.css
@@ -1,0 +1,4 @@
+:root {
+  /* Reduce Read the Docs' flyout font a little bit */
+  --readthedocs-flyout-font-size: 0.7rem;
+}

--- a/src/flyout.sphinx.furo.css
+++ b/src/flyout.sphinx.furo.css
@@ -1,0 +1,4 @@
+:root {
+  /* Reduce Read the Docs' flyout font a little bit */
+  --readthedocs-flyout-font-size: 0.75rem;
+}


### PR DESCRIPTION
Use our heuristic to detect the documentation tool/theme and add specific `--readthedocs-*` CSS variables based on that for known tools/themes.

Reference: https://github.com/readthedocs/readthedocs.org/pull/11849#issuecomment-2540234995