### PR TITLE
Don't show the `latest` notification if it's the default version

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -242,8 +242,9 @@ export class NotificationElement extends LitElement {
     //  - if the user is reading the "latest" version: shows a notification to warn
     //    the user about reading the latest development version.
     //  - if the user is reading a non-"stable" version: shows a notification to warn
-    //    the user about reading a version that may be old. Except if the reading version
-    //    is the project's default version.
+    //    the user about reading a version that may be old.
+    //  - Both notifications are skipped if the current version is the **default** version,
+    //    as we assume then the author wants the user to be reading that version.
     //
     // This does not cover all the cases where this notification could be useful,
     // but users with different needs should be able to implement their own custom logic.

--- a/src/notification.js
+++ b/src/notification.js
@@ -213,6 +213,8 @@ export class NotificationElement extends LitElement {
     if (
       this.readingLatestVersion &&
       this.stableVersionAvailable &&
+      this.config.versions.current.slug !==
+        this.config.projects.current.default_version &&
       objectPath.get(this.config, "addons.notifications.show_on_latest", false)
     ) {
       return this.renderLatestVersionWarning();

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -203,6 +203,20 @@
             expect(element).shadowDom.to.equal("");
           });
 
+          it("on default version that is latest", async () => {
+            config.projects.current.default_version = "latest";
+            config.versions.current.slug = "latest";
+
+            const addon = new notification.NotificationAddon(config);
+            const element = document.querySelector("readthedocs-notification");
+
+            // We need to wait for the element to renders/updates before querying it
+            await elementUpdated(element);
+
+            // The notification should not be displayed
+            expect(element).shadowDom.to.equal("");
+          });
+
           it("on external version", async () => {
             config.versions.current.slug = "381";
             config.versions.current.type = "external";


### PR DESCRIPTION
I think this is maybe a better default than https://github.com/readthedocs/readthedocs.org/pull/11874.

This should at least stop the "getting a notification when I hit the default version" issue. Though maybe it's better to default it to off, instead of this? I think we need to do _something_ to fix the current behavior because it's properly annoying (I hit the latest version warning like 3 times yesterday trying to do basic work, and it was never useful..)