### PR TITLE
Flyout: use theme default for `position`

### DIFF
--- a/src/flyout.js
+++ b/src/flyout.js
@@ -45,6 +45,14 @@ export class FlyoutElement extends LitElement {
       return;
     }
     this.config = config;
+
+    // The "position" is a value that can be defined from the dashboard.
+    // There are two main options: "Default" or a specific value.
+    // When "Default" is used, the value will be grabbed from the HTML element (e.g. explicitly set by the theme author).
+    // In case it's not defined, the value defined in the `constructor` will be used ("bottom-right")
+    this.position =
+      objectPath.get(this.config, "addons.flyout.position", null) ||
+      this.position;
   }
 
   _close() {

--- a/src/flyout.js
+++ b/src/flyout.js
@@ -50,9 +50,14 @@ export class FlyoutElement extends LitElement {
     // There are two main options: "Default" or a specific value.
     // When "Default" is used, the value will be grabbed from the HTML element (e.g. explicitly set by the theme author).
     // In case it's not defined, the value defined in the `constructor` will be used ("bottom-right")
-    this.position =
-      objectPath.get(this.config, "addons.flyout.position", null) ||
-      this.position;
+    const dashboardPosition = objectPath.get(
+      this.config,
+      "addons.flyout.position",
+      null,
+    );
+    if (dashboardPosition) {
+      this.position = dashboardPosition;
+    }
   }
 
   _close() {


### PR DESCRIPTION
Initial POC to prove if this idea is possible and how we feel about it.

I put together an example of what I understand we want to build here 😅 . In this example, the theme author will make explicitly how they want to use `readthedocs-flyout` HTML tag:

```html
<readthedocs-flyout position="top-right"></readthedocs-flyout>
```

That will add the class `top-right` and show the flyout as follows:

![Screenshot_2025-01-08_12-44-20](https://github.com/user-attachments/assets/14ed7946-a1ab-4c44-84dc-d2a9ee456b8c)

However, the project author can change the `position` value from the dashboard if they prefer to override the theme's default value:


![Peek 2025-01-08 12-46](https://github.com/user-attachments/assets/d8ab340b-2fc1-4704-ac0e-4a12bfe0ae07)

* Related #51
* Requires https://github.com/readthedocs/ext-theme/pull/554
* Requires https://github.com/readthedocs/readthedocs.org/pull/11891
* Example using https://test-builds.readthedocs.io/en/addons-theme-defaults/
* Closes #434