### PR TITLE
Show example of setting attributes and variables at parent DOM

### DIFF
--- a/src/doctools.css
+++ b/src/doctools.css
@@ -1,0 +1,25 @@
+/* Specific styles based on documentation tools and themes */
+html[data-readthedocs-tool="mkdocs-material"] {
+  --readthedocs-font-size: 0.6rem;
+  --readthedocs-flyout-font-size: 0.6rem;
+}
+
+html[data-readthedocs-tool="antora"] {
+  --readthedocs-font-size: 0.7rem;
+  --readthedocs-flyout-font-size: 0.7rem;
+}
+
+html[data-readthedocs-tool="mdbook"] {
+  --readthedocs-font-size: 1.3rem;
+  --readthedocs-flyout-font-size: 1.3rem;
+}
+
+html[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="furo"] {
+  --readthedocs-font-size: 0.75rem;
+  --readthedocs-flyout-font-size: 0.75rem;
+}
+
+html[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="immaterial"] {
+  --readthedocs-font-size: 0.65rem;
+  --readthedocs-flyout-font-size: 0.65rem;
+}

--- a/src/flyout.css
+++ b/src/flyout.css
@@ -1,4 +1,14 @@
-/* New */
+/* Flyout styles */
+
+:host {
+  /* These variables are used more than once, use a local variable so we can set
+   * a default in this addon */
+  --addons-flyout-font-size: var(
+    --readthedocs-flyout-font-size,
+    var(--readthedocs-font-size, 0.8rem)
+  );
+  --addons-flyout-line-height: var(--readthedocs-flyout-line-height, 1.25em);
+}
 
 .container {
   position: fixed;
@@ -7,7 +17,7 @@
   height: auto;
   max-height: calc(100% - 100px);
   overflow-y: auto;
-  line-height: 1rem;
+  line-height: var(--addons-flyout-line-height);
 }
 
 .container.bottom-right {
@@ -28,13 +38,6 @@
 .container.top-right {
   right: 20px;
   top: 50px;
-}
-
-:host {
-  --addons-flyout-font-size: var(
-    --readthedocs-flyout-font-size,
-    var(--readthedocs-font-size, 0.8rem)
-  );
 }
 
 :host > div {
@@ -155,29 +158,4 @@ hr {
 small a {
   text-decoration: none;
   color: var(--readthedocs-flyout-link-color, rgb(42, 128, 185));
-}
-
-/* Specific styles based on documentation tools and themes */
-div[data-tool="mkdocs-material"] {
-  --addons-flyout-font-size: 0.6rem;
-  line-height: 0.7rem;
-}
-
-div[data-tool="antora"] {
-  --addons-flyout-font-size: 0.7rem;
-  line-height: 0.9rem;
-}
-
-div[data-tool="mdbook"] {
-  --addons-flyout-font-size: 1.3rem;
-}
-
-div[data-tool="sphinx"][data-tool-theme="furo"] {
-  --addons-flyout-font-size: 0.75rem;
-  line-height: 0.9rem;
-}
-
-div[data-tool="sphinx"][data-tool-theme="immaterial"] {
-  --addons-flyout-font-size: 0.65rem;
-  line-height: 0.8rem;
 }

--- a/src/flyout.js
+++ b/src/flyout.js
@@ -8,12 +8,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { default as objectPath } from "object-path";
 
 import styleSheet from "./flyout.css";
-import {
-  AddonBase,
-  addUtmParameters,
-  getLinkWithFilename,
-  docTool,
-} from "./utils";
+import { AddonBase, addUtmParameters, getLinkWithFilename } from "./utils";
 import { SPHINX, MKDOCS_MATERIAL } from "./constants";
 import {
   EVENT_READTHEDOCS_SEARCH_SHOW,
@@ -320,11 +315,7 @@ export class FlyoutElement extends LitElement {
     }
 
     return html`
-      <div
-        data-tool="${docTool.documentationTool}"
-        data-tool-theme="${docTool.documentationTheme}"
-        class=${classMap(this.classes)}
-      >
+      <div class=${classMap(this.classes)}>
         ${this.renderHeader()}
         <main class=${classMap({ closed: !this.opened })}>
           ${this.renderLanguages()} ${this.renderVersions()}

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,15 @@ import * as filetreediff from "./filetreediff";
 import * as customscript from "./customscript";
 import { default as objectPath } from "object-path";
 import {
+  docTool,
   domReady,
   isEmbedded,
   IS_PRODUCTION,
   setupLogging,
   getMetadataValue,
 } from "./utils";
+
+import doctoolsStyleSheet from "./doctools.css";
 
 export function setup() {
   const addons = [
@@ -47,6 +50,28 @@ export function setup() {
           if (addon.requiresUrlParam()) {
             sendUrlParam = true;
             break;
+          }
+        }
+
+        // Apply fixes to variables for individual documentation tools
+        const elementHtml = document.querySelector("html");
+        if (elementHtml) {
+          // Inject styles at the parent DOM to set variables at :root
+          document.adoptedStyleSheets = [doctoolsStyleSheet];
+
+          // If we detect a documentation tool, set attributes on :root to allow
+          // for CSS selectors to utilize these values.
+          if (docTool.documentationTool) {
+            elementHtml.setAttribute(
+              "data-readthedocs-tool",
+              docTool.documentationTool,
+            );
+          }
+          if (docTool.documentationTheme) {
+            elementHtml.setAttribute(
+              "data-readthedocs-tool-theme",
+              docTool.documentationTheme,
+            );
           }
         }
 


### PR DESCRIPTION
This moves the inner CSS rules from inside the shadow DOM to the parent
DOM. This allows users to still set a `--readthedocs-font-size` and
similar variables.