### PR TITLE
Flyout: define `position="inline"`

### DIFF
--- a/src/flyout.css
+++ b/src/flyout.css
@@ -40,6 +40,20 @@
   top: 50px;
 }
 
+.container.inline {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  position: absolute;
+  bottom: 0;
+}
+
+@media screen and (max-width: 768px) {
+  .container.inline {
+    max-width: 100%;
+  }
+}
+
 :host > div {
   font-family: var(
     --readthedocs-flyout-font-family,

--- a/src/flyout.js
+++ b/src/flyout.js
@@ -26,7 +26,6 @@ export class FlyoutElement extends LitElement {
   static properties = {
     config: { state: true },
     opened: { type: Boolean },
-    floating: { type: Boolean },
     position: { type: String },
   };
 
@@ -37,7 +36,6 @@ export class FlyoutElement extends LitElement {
 
     this.config = null;
     this.opened = false;
-    this.floating = true;
     this.position = "bottom-right";
     this.readthedocsLogo = READTHEDOCS_LOGO;
   }
@@ -327,7 +325,7 @@ export class FlyoutElement extends LitElement {
   }
 
   updateCSSClasses() {
-    this.classes = { floating: this.floating, container: true };
+    this.classes = { container: true };
     this.classes[this.position] = true;
   }
 


### PR DESCRIPTION
Allow theme developers to define `position="inline"` to adapt the flyout to its container. It uses `bottom: 0` to make it open up side, and it should probably use `top: 0` to make it open down side.