### PR TITLE
Use inline positioning instead of absolute

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,29 @@
       <h2 id="customscript">CustomScript</h2>
       <p>Content of the section</p>
 
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <div style="width: 20em; background: red;">
+        <readthedocs-flyout position="inline"></readthedocs-flyout>
+      </div>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <!-- Pretend this is a sidebar menu -->
+      <div style="width: 20em; position: fixed; left: 0; top: 100; background: red;">
+        <readthedocs-flyout position="top-left inline"></readthedocs-flyout>
+      </div>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+      <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
+
       <h2 id="search">Search</h2>
       <p>Hit <code>/</code> to trigger the search modal, or click on the input from the flyout.</p>
       <readthedocs-search></readthedocs-search>

--- a/src/flyout.css
+++ b/src/flyout.css
@@ -20,32 +20,34 @@
   line-height: var(--addons-flyout-line-height);
 }
 
-.container.bottom-right {
+.container.bottom-right:not(.inline) {
   right: 20px;
   bottom: 50px;
 }
 
-.container.bottom-left {
+.container.bottom-left:not(.inline) {
   left: 20px;
   bottom: 50px;
 }
 
-.container.top-left {
+.container.top-left:not(.inline) {
   left: 20px;
   top: 50px;
 }
 
-.container.top-right {
+.container.top-right:not(.inline) {
   right: 20px;
   top: 50px;
 }
 
 .container.inline {
   width: calc(100% - 20px);
+  max-width: 100%;
   padding: 0 10px;
   margin: 0;
-  position: absolute;
-  bottom: 0;
+  position: relative;
+  display: inline-block;
+  overflow: visible;
 }
 
 @media screen and (max-width: 768px) {
@@ -130,7 +132,26 @@ main {
   margin-top: 5px;
 }
 
-main.closed {
+.container.inline main {
+  position: absolute;
+  bottom: 3em;
+  padding: 1em;
+  background-color: var(--readthedocs-flyout-background-color, rgb(39, 39, 37));
+}
+
+/* This is where `.container.top-left` would be better as `.container.top.left`, giving an independent `top` */
+.container.bottom-left.inline main,
+.container.bottom-right.inline main {
+  bottom: 3em;
+  top: unset;
+}
+.container.top-left.inline main,
+.container.top-right.inline main {
+  top: 3em;
+  bottom: unset;
+}
+
+main.closed, .container.inline main.closed {
   display: none;
 }
 


### PR DESCRIPTION
Here is a quick example of using inline positioning. I've reused
`top-left` position to indicate "downward expanding menu" but this could
be something more explicit. It would be nice as `position="inline down"`
perhaps.

There are two basic examples, one truly inline and one flyout inside a
mock sidebar menu -- just to illustrate a theme maintainer nesting the
flyout element inside another element.

The tricky part here is making the `main` menu "float" over other
content, and we use `overflow: visible` and absolute positioning to
allow content to reflow around the element.

There are some fixes required here: too narrow of a parent clips the
collapsed menu, we probably want a max width on the popup menu (keeping
the collapsed menu width 100% (this is to fill the parent element).