### PR TITLE
Make notification copy a bit cleaner.

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -297,7 +297,7 @@ export class NotificationElement extends LitElement {
           This is the latest development version ${this.renderCloseButton()}
         </div>
         <div class="content">
-          Some features may only be avilable in the
+          Some features may not yet be available in the
           <a href="${this.urls.stable}">stable version</a>.
         </div>
       </div>

--- a/src/notification.js
+++ b/src/notification.js
@@ -320,7 +320,7 @@ export class NotificationElement extends LitElement {
         </div>
         <div class="content">
           Refer to the <a href="${this.urls.stable}">stable version</a> for the
-          most up-to-date version.
+          most current documentation.
         </div>
       </div>
     `;

--- a/src/notification.js
+++ b/src/notification.js
@@ -294,14 +294,11 @@ export class NotificationElement extends LitElement {
       <div>
         ${iconFlask.node[0]}
         <div class="title">
-          This is the <span>latest development version</span>
-          ${this.renderCloseButton()}
+          This is the latest development version ${this.renderCloseButton()}
         </div>
         <div class="content">
-          Some features may not yet be available in the published stable
-          version. Read the
-          <a href="${this.urls.stable}">stable version of this documentation</a
-          >.
+          Some features may only be avilable in the
+          <a href="${this.urls.stable}">stable version</a>.
         </div>
       </div>
     `;
@@ -322,10 +319,8 @@ export class NotificationElement extends LitElement {
           ${this.renderCloseButton()}
         </div>
         <div class="content">
-          You may be reading an old version of this documentation. Read the
-          <a href="${this.urls.stable}"
-            >latest stable version of this documentation</a
-          >.
+          Refer to the <a href="${this.urls.stable}">stable version</a> for the
+          most up-to-date version.
         </div>
       </div>
     `;
@@ -348,7 +343,7 @@ export class NotificationElement extends LitElement {
         <div class="content">
           See the
           <a href="${addUtmParameters(this.urls.build, "notification")}"
-            >build's detail page</a
+            >build detail page</a
           >
           or
           <a href="${this.urls.external}"

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -115,8 +115,12 @@
             await elementUpdated(element);
 
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
+            expect(title.innerText).to.include(
               "This may be an old version of this documentation",
+            );
+            const content = element.shadowRoot.querySelector("div.content");
+            expect(content.innerHTML).to.include(
+              '<a href="https://project.readthedocs.io/en/stable/section/page.html">'
             );
           });
 
@@ -132,6 +136,10 @@
             const title = element.shadowRoot.querySelector("div.title");
             expect(title.innerText).to.include(
               "This is the latest development version"
+            );
+            const content = element.shadowRoot.querySelector("div.content");
+            expect(content.innerHTML).to.include(
+              '<a href="https://project.readthedocs.io/en/stable/section/page.html">'
             );
           });
 
@@ -149,6 +157,10 @@
             const title = element.shadowRoot.querySelector("div.title");
             expect(title.innerText).to.include(
               "This is the latest development version"
+            );
+            const content = element.shadowRoot.querySelector("div.content");
+            expect(content.innerHTML).to.include(
+              '<a href="https://project.readthedocs.io/en/stable/section/page.html">'
             );
           });
 
@@ -191,8 +203,12 @@
             await elementUpdated(element);
 
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
+            expect(title.innerText).to.include(
               "This page was created from a pull request build",
+            );
+            const content = element.shadowRoot.querySelector("div.content");
+            expect(content.innerHTML).to.include(
+              '<a href="https://app.readthedocs.org/project/project/builds/?utm_source=project&amp;utm_content=notification">build detail page</a>'
             );
           });
 
@@ -276,7 +292,7 @@
 
             // The notification should be displayed normally
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
+            expect(title.innerText).to.include(
               "This page was created from a pull request build",
             );
           });

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -115,7 +115,7 @@
             await elementUpdated(element);
 
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.include(
+            expect(title.innerText).to.be.equal(
               "This may be an old version of this documentation",
             );
             const content = element.shadowRoot.querySelector("div.content");
@@ -134,7 +134,7 @@
             await elementUpdated(element);
 
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.include(
+            expect(title.innerText).to.be.equal(
               "This is the latest development version"
             );
             const content = element.shadowRoot.querySelector("div.content");
@@ -155,7 +155,7 @@
             await elementUpdated(element);
 
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.include(
+            expect(title.innerText).to.be.equal(
               "This is the latest development version"
             );
             const content = element.shadowRoot.querySelector("div.content");
@@ -203,7 +203,7 @@
             await elementUpdated(element);
 
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.include(
+            expect(title.innerText).to.be.equal(
               "This page was created from a pull request build",
             );
             const content = element.shadowRoot.querySelector("div.content");
@@ -292,7 +292,7 @@
 
             // The notification should be displayed normally
             const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.include(
+            expect(title.innerText).to.be.equal(
               "This page was created from a pull request build",
             );
           });

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -129,29 +129,10 @@
             // We need to wait for the element to renders/updates before querying it
             await elementUpdated(element);
 
-            expect(element).shadowDom.to.equal(`
-<div>
-  <div class="title">
-    This is the
-    <span>
-      latest development version
-    </span>
-    <a
-      class="right"
-      href="#"
-    >
-    </a>
-  </div>
-  <div class="content">
-    Some features may not yet be available in the published stable
-          version. Read the
-    <a href="https://project.readthedocs.io/en/stable/section/page.html">
-      stable version of this documentation
-    </a>
-    .
-  </div>
-</div>
-      `);
+            const title = element.shadowRoot.querySelector("div.title");
+            expect(title.innerText).to.include(
+              "This is the latest development version"
+            );
           });
 
           it("on latest version (multiple_versions_without_translations)", async () => {
@@ -165,28 +146,10 @@
             // We need to wait for the element to renders/updates before querying it
             await elementUpdated(element);
 
-            expect(element).shadowDom.to.equal(`
-<div>
-  <div class="title">
-    This is the
-    <span>
-      latest development version
-    </span>
-    <a
-      class="right"
-      href="#"
-    >
-    </a>
-  </div>
-  <div class="content">
-    Some features may not yet be available in the published stable
-          version. Read the
-    <a href="https://project.readthedocs.io/en/stable/section/page.html">
-      stable version of this documentation
-    </a>
-    .
- </div>
-`);
+            const title = element.shadowRoot.querySelector("div.title");
+            expect(title.innerText).to.include(
+              "This is the latest development version"
+            );
           });
 
           it("on default version when stable is available", async () => {


### PR DESCRIPTION
This also makes the latest version warning 1 line, taking less vertical space.