### PR TITLE
Trigger the URL_CHANGED event only if from/to URL are different

### DIFF
--- a/src/linkpreviews.js
+++ b/src/linkpreviews.js
@@ -273,7 +273,9 @@ export class LinkPreviewsElement extends LitElement {
 
   _handleRootDOMChanged = (e) => {
     // Trigger the setup again since the DOM has changed
-    this.setupTooltips();
+    if (this.config) {
+      this.setupTooltips();
+    }
   };
 
   connectedCallback() {


### PR DESCRIPTION
Check if from/to URL are different after removing `?readthedocs-diff=`
attribute because we don't want to trigger the even when the user enabled
docdiff in the current page.

Closes #506