### PR TITLE
Docdiff: use Embed API to grab the base URL content

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,3 +17,6 @@ export const SPHINX_ALABASTER = "alabaster";
 export const SPHINX_FURO = "furo";
 export const SPHINX_READTHEDOCS = "readthedocs";
 export const SPHINX_IMMATERIAL = "immaterial";
+
+// API URLs
+export const EMBED_API_ENDPOINT = "/_/api/v3/embed/";

--- a/src/docdiff.js
+++ b/src/docdiff.js
@@ -20,6 +20,7 @@ import {
 import { nothing, LitElement } from "lit";
 import { default as objectPath } from "object-path";
 import { hasQueryParam, docTool } from "./utils";
+import { EMBED_API_ENDPOINT } from "./constants";
 
 export const DOCDIFF_URL_PARAM = "readthedocs-diff";
 
@@ -84,7 +85,7 @@ export class DocDiffElement extends LitElement {
     this.injectStyles = true;
 
     this.originalBody = null;
-    this.cachedRemoteContent = null;
+    this.cachedRemoteResponse = null;
   }
 
   loadConfig(config) {
@@ -113,47 +114,43 @@ export class DocDiffElement extends LitElement {
 
   render() {
     return nothing;
-    // TODO: render a checkbox once we are settled on the UI.
-    // For now, we are only enabling/disabling via a hotkey.
-    //
-    // return html`
-    //   <label class="switch">
-    //     <input @click="${this.handleClick}" type="checkbox" />
-    //     <span class="slider round"></span>
-    //   </label>
-    // `;
   }
 
-  // This code isn't used until we show a UI,
-  // and even then we'll want to trigger events to match state?
-  // handleClick(e) {
-  //   if (e.target.checked) {
-  //     this.enableDocDiff();
-  //   } else {
-  //     this.disableDocDiff();
-  //   }
-  // }
+  getEmbedURL(url) {
+    const params = {
+      url: url,
+    };
+
+    if (this.rootSelector !== null) {
+      params["maincontent"] = this.rootSelector;
+    }
+
+    // NOTE: we don't send ``doctool`` and ``docversion`` on purpose here
+    // because we don't want the backed to pre-process the response. We need the
+    // HTML as-is without any pre-processing.
+    return EMBED_API_ENDPOINT + "?" + new URLSearchParams(params).toString();
+  }
 
   compare() {
     let promiseData;
 
-    if (this.cachedRemoteContent !== null) {
-      promiseData = Promise.resolve(this.cachedRemoteContent);
+    if (this.cachedRemoteResponse !== null) {
+      promiseData = Promise.resolve(this.cachedRemoteResponse);
     } else {
-      promiseData = fetch(this.config.addons.doc_diff.base_url).then(
-        (response) => {
-          if (!response.ok) {
-            throw new Error("Error downloading requested base URL.");
-          }
-          return response.text();
-        },
-      );
+      const baseURL = this.config.addons.doc_diff.base_url;
+      const url = this.getEmbedURL(baseURL);
+      promiseData = fetch(url).then((response) => {
+        if (!response.ok) {
+          throw new Error("Error downloading requested base URL.");
+        }
+        return response.json();
+      });
     }
 
     promiseData
-      .then((text) => {
-        this.cachedRemoteContent = text;
-        this.performDiff(text);
+      .then((data) => {
+        this.cachedRemoteResponse = data;
+        this.performDiff(this.cachedRemoteResponse.content);
       })
       .finally(() => {
         const event = new CustomEvent(EVENT_READTHEDOCS_ROOT_DOM_CHANGED);
@@ -168,22 +165,22 @@ export class DocDiffElement extends LitElement {
   // with the resulting visual diff elements instead.
   performDiff(remoteContent) {
     const parser = new DOMParser();
-    const html_document = parser.parseFromString(remoteContent, "text/html");
-    const old_body = html_document.documentElement.querySelector(
+    const htmlDocument = parser.parseFromString(remoteContent, "text/html");
+    const oldBody = htmlDocument.documentElement.querySelector(
       this.rootSelector,
     );
-    const new_body = document.querySelector(this.rootSelector);
+    const newBody = document.querySelector(this.rootSelector);
 
-    if (old_body == null || new_body == null) {
+    if (oldBody == null || newBody == null) {
       throw new Error("Element not found in both documents.");
     }
 
     const diffNode = visualDomDiff.visualDomDiff(
-      old_body,
-      new_body,
+      oldBody,
+      newBody,
       VISUAL_DIFF_OPTIONS,
     );
-    new_body.replaceWith(diffNode.firstElementChild);
+    newBody.replaceWith(diffNode.firstElementChild);
   }
 
   enableDocDiff() {

--- a/src/linkpreviews.js
+++ b/src/linkpreviews.js
@@ -9,6 +9,7 @@ import {
   docTool,
 } from "./utils";
 import { EVENT_READTHEDOCS_ROOT_DOM_CHANGED } from "./events";
+import { EMBED_API_ENDPOINT } from "./constants";
 import {
   computePosition,
   autoPlacement,
@@ -195,9 +196,7 @@ function setupTooltip(el, doctoolname, doctoolversion, selector) {
       params["maincontent"] = selector;
     }
 
-    const api_url =
-      "/_/api/v3/embed/?" + new URLSearchParams(params).toString();
-    return api_url;
+    return EMBED_API_ENDPOINT + "?" + new URLSearchParams(params).toString();
   }
 }
 


### PR DESCRIPTION
Fetching a documentation URL is blocked because of CORS in Read the Docs for Business, so we use Embed API to fetch the content we need to perform the docdiff.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/1942