### PR TITLE
Visual diff: add extra CSS chunk selectors

### DIFF
--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -35,11 +35,14 @@ export class FileTreeDiffElement extends LitElement {
     this.chunks = [];
     this.chunkTagSelector = [
       // We may want to add more selectors here as we find them.
+      "section",
       "h1",
       "h2",
       "h3",
       "p",
       "dl",
+      "ul",
+      "ol",
       "table",
       "pre",
     ];


### PR DESCRIPTION
This will help detecting changes inside `section`, `ul` and `ol`.

Example: https://writethedocs-www--2299.org.readthedocs.build/conf/index.html?readthedocs-diff=true