### PR TITLE
Filetreediff: allow users to ignore some files

### DIFF
--- a/src/data-validation.js
+++ b/src/data-validation.js
@@ -257,7 +257,7 @@ const addons_filetreediff = {
       properties: {
         filetreediff: {
           type: "object",
-          required: ["enabled", "diff"],
+          required: ["enabled", "diff", "ignored_files"],
           properties: {
             enabled: { type: "boolean" },
             diff: {
@@ -268,6 +268,7 @@ const addons_filetreediff = {
                 modified: { type: "array" },
               },
             },
+            ignored_files: { type: ["array", "null"] },
           },
         },
       },

--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -216,10 +216,10 @@ export class FileTreeDiffElement extends LitElement {
     // Filter out files that are ignored by this project
     const ignoredFiles = this.config.addons.filetreediff.ignored_files || [];
     const addedFiles = diffData.added.filter(
-      (file) => !ignoredFiles.contains(file),
+      (file) => !ignoredFiles.includes(file.filename),
     );
     const modifiedFiles = diffData.modified.filter(
-      (file) => !ignoredFiles.contains(file),
+      (file) => !ignoredFiles.includes(file.filename),
     );
 
     return html`

--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -213,13 +213,21 @@ export class FileTreeDiffElement extends LitElement {
       (f) => f.urls.current === currentUrl,
     );
 
+    const testIgnoredfile = (file) => {
+      for (const re of ignoredFiles) {
+        let regex = new RegExp(re);
+        if (regex.test(file.filename)) {
+          return false;
+        }
+      }
+      return true;
+    };
+
     // Filter out files that are ignored by this project
     const ignoredFiles = this.config.addons.filetreediff.ignored_files || [];
-    const addedFiles = diffData.added.filter(
-      (file) => !ignoredFiles.includes(file.filename),
-    );
-    const modifiedFiles = diffData.modified.filter(
-      (file) => !ignoredFiles.includes(file.filename),
+    const addedFiles = diffData.added.filter((file) => testIgnoredfile(file));
+    const modifiedFiles = diffData.modified.filter((file) =>
+      testIgnoredfile(file),
     );
 
     return html`

--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -213,6 +213,15 @@ export class FileTreeDiffElement extends LitElement {
       (f) => f.urls.current === currentUrl,
     );
 
+    // Filter out files that are ignored by this project
+    const ignoredFiles = this.config.addons.filetreediff.ignored_files || [];
+    const addedFiles = diffData.added.filter(
+      (file) => !ignoredFiles.contains(file),
+    );
+    const modifiedFiles = diffData.modified.filter(
+      (file) => !ignoredFiles.contains(file),
+    );
+
     return html`
       <div>
         <div>
@@ -221,8 +230,8 @@ export class FileTreeDiffElement extends LitElement {
             <option value="" ?selected=${!hasCurrentFile} disabled>
               Files changed
             </option>
-            ${renderSection(diffData.added, "Added")}
-            ${renderSection(diffData.modified, "Changed")}
+            ${renderSection(addedFiles, "Added")}
+            ${renderSection(modifiedFiles, "Changed")}
           </select>
         </div>
       </div>

--- a/tests/__snapshots__/filetreediff.test.snap.js
+++ b/tests/__snapshots__/filetreediff.test.snap.js
@@ -1,0 +1,34 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Filetreediff tests snapshot filetreediff completely"] = 
+`<div>
+  <div>
+    <label>
+      <input type="checkbox">
+      Show diff
+    </label>
+    <select>
+      <option
+        disabled=""
+        selected=""
+        value=""
+      >
+        Files changed
+      </option>
+      <optgroup label="Added">
+        <option value="http://project.readthedocs.io/en/latest/testing.html">
+          + testing.html
+        </option>
+      </optgroup>
+      <optgroup label="Changed">
+        <option value="http://project.readthedocs.io/en/latest/commercial.html">
+          ± commercial.html
+        </option>
+      </optgroup>
+    </select>
+  </div>
+</div>
+`;
+/* end snapshot Filetreediff tests snapshot filetreediff completely */
+

--- a/tests/filetreediff.test.html
+++ b/tests/filetreediff.test.html
@@ -16,25 +16,51 @@
           config = {
             addons: {
               doc_diff: {
-                  enabled: true,
+                enabled: true,
               },
               filetreediff: {
-                  enabled: true,
-                  ignored_files: [
-                    "^ignored/.+\.html",
+                enabled: true,
+                ignored_files: ["^ignored/.+\.html"],
+                diff: {
+                  added: [
+                    {
+                      filename: "testing.html",
+                      urls: {
+                        current:
+                          "http://project.readthedocs.io/en/latest/testing.html",
+                        base: "https://project.readthedocs.io/en/base/testing.html",
+                      },
+                    },
                   ],
-                  diff: {
-                      added: [
-                          {filename: "testing.html", urls: {current: "http://project.readthedocs.io/en/latest/testing.html", base: "https://project.readthedocs.io/en/base/testing.html"}},
-                      ],
-                      modified: [
-                          {filename: "ignored/index.html", urls: {current: "http://project.readthedocs.io/en/latest/ignored/index.html", base: "https://project.readthedocs.io/en/base/ignored/index.html"}},
-                          {filename: "commercial.html", urls: {current: "http://project.readthedocs.io/en/latest/commercial.html", base: "https://project.readthedocs.io/en/base/commercial.html"}},
-                      ],
-                      deleted: [
-                          {filename: "deleted.html", urls: {current: "http://project.readthedocs.io/en/latest/deleted.html", base: "https://project.readthedocs.io/en/base/deleted.html"}},
-                      ],
-                  },
+                  modified: [
+                    {
+                      filename: "ignored/index.html",
+                      urls: {
+                        current:
+                          "http://project.readthedocs.io/en/latest/ignored/index.html",
+                        base: "https://project.readthedocs.io/en/base/ignored/index.html",
+                      },
+                    },
+                    {
+                      filename: "commercial.html",
+                      urls: {
+                        current:
+                          "http://project.readthedocs.io/en/latest/commercial.html",
+                        base: "https://project.readthedocs.io/en/base/commercial.html",
+                      },
+                    },
+                  ],
+                  deleted: [
+                    {
+                      filename: "deleted.html",
+                      urls: {
+                        current:
+                          "http://project.readthedocs.io/en/latest/deleted.html",
+                        base: "https://project.readthedocs.io/en/base/deleted.html",
+                      },
+                    },
+                  ],
+                },
               },
             },
           };

--- a/tests/filetreediff.test.html
+++ b/tests/filetreediff.test.html
@@ -1,0 +1,59 @@
+<html>
+  <head>
+    <meta name="readthedocs-project-slug" content="project" />
+    <meta name="readthedocs-resolver-filename" content="/" />
+  </head>
+  <body>
+    <script type="module">
+      import { expect, elementUpdated } from "@open-wc/testing";
+      import { runTests } from "@web/test-runner-mocha";
+      import * as filetreediff from "../src/filetreediff";
+
+      let config;
+
+      runTests(async () => {
+        beforeEach(() => {
+          config = {
+            addons: {
+              doc_diff: {
+                  enabled: true,
+              },
+              filetreediff: {
+                  enabled: true,
+                  ignored_files: [
+                    "^ignored/.+\.html",
+                  ],
+                  diff: {
+                      added: [
+                          {filename: "testing.html", urls: {current: "http://project.readthedocs.io/en/latest/testing.html", base: "https://project.readthedocs.io/en/base/testing.html"}},
+                      ],
+                      modified: [
+                          {filename: "ignored/index.html", urls: {current: "http://project.readthedocs.io/en/latest/ignored/index.html", base: "https://project.readthedocs.io/en/base/ignored/index.html"}},
+                          {filename: "commercial.html", urls: {current: "http://project.readthedocs.io/en/latest/commercial.html", base: "https://project.readthedocs.io/en/base/commercial.html"}},
+                      ],
+                      deleted: [
+                          {filename: "deleted.html", urls: {current: "http://project.readthedocs.io/en/latest/deleted.html", base: "https://project.readthedocs.io/en/base/deleted.html"}},
+                      ],
+                  },
+              },
+            },
+          };
+        });
+
+        describe("Filetreediff tests", () => {
+          it("snapshot filetreediff completely", async () => {
+            const addon = new filetreediff.FileTreeDiffAddon(config);
+            const element = document.querySelector("readthedocs-filetreediff");
+
+            await elementUpdated(element);
+            await expect(element).shadowDom.to.equalSnapshot();
+          });
+        });
+      });
+    </script>
+
+    <main>
+      <p>This was <span class=".doc-diff-added">added</span>.</p>
+    </main>
+  </body>
+</html>

--- a/tests/filetreediff.test.js
+++ b/tests/filetreediff.test.js
@@ -38,6 +38,7 @@ describe("FileTreeDiff addon", () => {
         addons: {
           filetreediff: {
             enabled: true,
+            ignored_files: ["^changelogs/.+.html$", "guides/index.html"],
             diff: {
               added: [],
               modified: [],


### PR DESCRIPTION
Filter the added/modified list of files to filter our "ignored files" coming from the API response.

[Peek 2025-02-05 14-26.webm](https://github.com/user-attachments/assets/f6e45326-fead-4f40-8b76-36a82b1d6cb0)


Requires readthedocs/readthedocs.org#11977