### PR TITLE
Resolver filename fixes

### DIFF
--- a/src/data-validation.js
+++ b/src/data-validation.js
@@ -250,7 +250,7 @@ const addons_flyout = {
           type: "object",
           required: ["filename"],
           properties: {
-            filename: { type: "string" },
+            filename: { type: ["string", "null"] },
           },
         },
       },
@@ -463,7 +463,7 @@ const addons_notifications = {
           type: "object",
           required: ["filename"],
           properties: {
-            filename: { type: "string" },
+            filename: { type: ["string", "null"] },
           },
         },
       },

--- a/src/utils.js
+++ b/src/utils.js
@@ -360,9 +360,7 @@ export function getLinkWithFilename(url, resolverFilename) {
       // Normal case for most of the documentation tools.
       // Get the resolver's filename returned by the application (as HTTP header)
       // and injected by Cloudflare Worker as a meta HTML tag
-      const resolverFilename = getMetadataValue(
-        "readthedocs-resolver-filename",
-      );
+      resolverFilename = getMetadataValue("readthedocs-resolver-filename");
     }
   }
 


### PR DESCRIPTION
Make flyout work when `readthedocs.resolver.filename` is `null`. In that case, we get this value from the META tag added by Cloudflare.

This was the original intent here, but I missed allowing `null` in the data validation. Besides, even if the data validation allows `null`, there was another bug since I was re-defining the variable (`const ...`) instead of overriding its value.

We didn't catch this locally because we have a different rule that makes the request to always contain `url=` parameter and that case is not affected by this.

Besides, I didn't find this when doing QA after deploy because I tested with examples that sent `url=` parameter.

I'll see if I can write a test for this in another PR.