### PR TITLE
`isEnabled` order of check

### DIFF
--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -323,8 +323,8 @@ export class EthicalAdsAddon extends AddonBase {
 
   static isEnabled(config, httpStatus) {
     return (
-      super.isEnabled(config, httpStatus) &&
-      config.addons.ethicalads.ad_free === false
+      config.addons.ethicalads.ad_free === false &&
+      super.isEnabled(config, httpStatus)
     );
   }
 }

--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -344,8 +344,10 @@ export class FileTreeDiffAddon extends AddonBase {
 
   static isEnabled(config, httpStatus) {
     return (
-      super.isEnabled(config, httpStatus) &&
-      config.versions.current.type === "external"
+      // The order is important since we don't even want to run the data
+      // validation if the version is not external.
+      config.versions.current.type === "external" &&
+      super.isEnabled(config, httpStatus)
     );
   }
 }


### PR DESCRIPTION
We want to validate _first_ for the simplest condition and if that condition is met, we want to perform the other more expensive checks.

This avoid raising "Validation error on..." for every page when the version is not external, for example.