### PR TITLE
EthicalAd: minor fix when checking `isEnabled`

### DIFF
--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -323,7 +323,7 @@ export class EthicalAdsAddon extends AddonBase {
 
   static isEnabled(config, httpStatus) {
     return (
-      config.addons.ethicalads.ad_free === false &&
+      objectPath.get(config, "addons.ethicalads.ad_free", false) === false &&
       super.isEnabled(config, httpStatus)
     );
   }


### PR DESCRIPTION
This was causing the addon to break