### PR TITLE
Links preview: cache requests to API

### DIFF
--- a/tests/__snapshots__/search.test.snap.js
+++ b/tests/__snapshots__/search.test.snap.js
@@ -65,7 +65,7 @@ snapshots["Search tests show the modal and perform a query"] =
   <div class="background">
   </div>
   <div class="content">
-    <form class="focus">
+    <form>
       <label>
       </label>
       <input
@@ -152,7 +152,7 @@ snapshots["Search tests show the modal and perform a query with no results"] =
   <div class="background">
   </div>
   <div class="content">
-    <form class="focus">
+    <form>
       <label>
       </label>
       <input
@@ -268,7 +268,7 @@ snapshots["Search tests initial trigger by event and DOM check with filters"] =
   <div class="background">
   </div>
   <div class="content">
-    <form class="focus">
+    <form>
       <label>
       </label>
       <input

--- a/tests/search.test.html
+++ b/tests/search.test.html
@@ -74,7 +74,9 @@
             document.dispatchEvent(searchEvent);
 
             await elementUpdated(element);
-            await expect(element).shadowDom.to.equalSnapshot();
+            await expect(element).shadowDom.to.equalSnapshot({
+              ignoreAttributes: [{ tags: ["form"], attributes: ["class"] }],
+            });
           });
 
           it("show the modal and perform a query with no results", async () => {
@@ -104,7 +106,9 @@
                 ),
               "No-results block was not rendered",
             );
-            await expect(element).shadowDom.to.equalSnapshot();
+            await expect(element).shadowDom.to.equalSnapshot({
+              ignoreAttributes: [{ tags: ["form"], attributes: ["class"] }],
+            });
           });
 
           it("show the modal and perform a query", async () => {
@@ -130,7 +134,9 @@
               () => element.shadowRoot.querySelector("div.results > div.hit"),
               "Hit result was not rendered",
             );
-            await expect(element).shadowDom.to.equalSnapshot();
+            await expect(element).shadowDom.to.equalSnapshot({
+              ignoreAttributes: [{ tags: ["form"], attributes: ["class"] }],
+            });
           });
         });
       });


### PR DESCRIPTION
Keep a cache of all the API request calls done and re-use them when the same link is previewed again. It follows the same logic we use on docdiff.