### PR TITLE
Remove PR build notification and add info to Visual Diff

### DIFF
--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -212,7 +212,7 @@ export class FileTreeDiffElement extends LitElement {
                 Go to build log
               </option>
               <option value="${this.config.versions.current.urls.vcs}">
-                Go to #${this.config.versions.current.slug}
+                Go to pull request #${this.config.versions.current.slug}
               </option>
               <option
                 value="https://docs.readthedocs.com/platform/stable/visual-diff.html"

--- a/src/filetreediff.js
+++ b/src/filetreediff.js
@@ -11,6 +11,7 @@ import {
 } from "./events";
 import { getQueryParam } from "./utils";
 import { AddonBase } from "./utils";
+import { addUtmParameters } from "./utils";
 
 const SCROLL_OFFSET_Y = 0.1;
 
@@ -197,10 +198,28 @@ export class FileTreeDiffElement extends LitElement {
           ${this.renderDocDiff()}
           <select @change=${this.handleFileChange}>
             <option value="" ?selected=${!hasCurrentFile} disabled>
-              Files changed
+              Files changed in #${this.config.versions.current.slug}
             </option>
             ${renderSection(diffData.added, "Added")}
             ${renderSection(diffData.modified, "Changed")}
+            <optgroup label="Links">
+              <option
+                value="${addUtmParameters(
+                  this.config.builds.current.urls.build,
+                  "notification",
+                )}"
+              >
+                Go to build log
+              </option>
+              <option value="${this.config.versions.current.urls.vcs}">
+                Go to #${this.config.versions.current.slug}
+              </option>
+              <option
+                value="https://docs.readthedocs.com/platform/stable/visual-diff.html"
+              >
+                Go to Visual Diff documentation
+              </option>
+            </optgroup>
           </select>
         </div>
       </div>
@@ -347,8 +366,10 @@ export class FileTreeDiffAddon extends AddonBase {
       // The order is important since we don't even want to run the data
       // validation if the version is not external.
       // We have to use `objectPath` here becase we haven't validated the data yet.
-      objectPath.get(config, "versions.current.type") === "external" &&
-      super.isEnabled(config, httpStatus)
+      (objectPath.get(config, "versions.current.type") === "external" &&
+        super.isEnabled(config, httpStatus)) ||
+      window.location.host.endsWith(".devthedocs.org") ||
+      window.location.host.endsWith(".devthedocs.com")
     );
   }
 }

--- a/src/notification.js
+++ b/src/notification.js
@@ -34,8 +34,6 @@ export class NotificationElement extends LitElement {
     this.timerID = null;
     this.config = null;
     this.urls = {
-      build: null,
-      external: null,
       stable: null,
     };
     this.readingLatestVersion = false;
@@ -133,21 +131,6 @@ export class NotificationElement extends LitElement {
     }
 
     this.config = config;
-
-    if (
-      this.config.addons.notifications.enabled &&
-      this.config.versions.current.type === "external"
-    ) {
-      this.urls = {
-        // NOTE: point users to the new beta dashboard for now so we promote it more.
-        // We will revert this once we are fully migrated to the new dashboard.
-        build: config.builds.current.urls.build
-          .replace("readthedocs.org", "app.readthedocs.org")
-          .replace("readthedocs.com", "app.readthedocs.com")
-          .replace("app.app.", "app."),
-        external: config.versions.current.urls.vcs,
-      };
-    }
 
     if (
       objectPath.get(

--- a/src/notification.js
+++ b/src/notification.js
@@ -3,7 +3,6 @@ import { library, icon } from "@fortawesome/fontawesome-svg-core";
 import {
   faCircleXmark,
   faFlask,
-  faCodePullRequest,
   faHourglassHalf,
 } from "@fortawesome/free-solid-svg-icons";
 import { html, nothing, render, LitElement } from "lit";
@@ -199,15 +198,7 @@ export class NotificationElement extends LitElement {
     }
 
     if (this.config.versions.current.type === "external") {
-      if (
-        objectPath.get(
-          this.config,
-          "addons.notifications.show_on_external",
-          false,
-        )
-      ) {
-        return this.renderExternalVersionWarning();
-      }
+      return nothing;
     }
 
     if (
@@ -329,35 +320,6 @@ export class NotificationElement extends LitElement {
           <a href="${this.urls.stable}"
             >latest stable version of this documentation</a
           >.
-        </div>
-      </div>
-    `;
-  }
-
-  renderExternalVersionWarning() {
-    library.add(faCodePullRequest);
-    const iconPullRequest = icon(faCodePullRequest, {
-      title: "This version is a pull request version",
-      classes: ["header", "icon"],
-    });
-
-    return html`
-      <div>
-        ${iconPullRequest.node[0]}
-        <div class="title">
-          This page was created from a pull request build
-          ${this.renderCloseButton()}
-        </div>
-        <div class="content">
-          See the
-          <a href="${addUtmParameters(this.urls.build, "notification")}"
-            >build's detail page</a
-          >
-          or
-          <a href="${this.urls.external}"
-            >pull request #${this.config.versions.current.slug}</a
-          >
-          for more information.
         </div>
       </div>
     `;

--- a/tests/__snapshots__/filetreediff.test.snap.js
+++ b/tests/__snapshots__/filetreediff.test.snap.js
@@ -14,7 +14,7 @@ snapshots["Filetreediff tests snapshot filetreediff completely"] =
         selected=""
         value=""
       >
-        Files changed
+        Files changed in #123
       </option>
       <optgroup label="Added">
         <option value="http://project.readthedocs.io/en/latest/testing.html">
@@ -24,6 +24,17 @@ snapshots["Filetreediff tests snapshot filetreediff completely"] =
       <optgroup label="Changed">
         <option value="http://project.readthedocs.io/en/latest/commercial.html">
           ± commercial.html
+        </option>
+      </optgroup>
+      <optgroup label="Links">
+        <option value="http://example.com/build/456?utm_source=project&amp;utm_content=notification">
+          Go to build log
+        </option>
+        <option value="http://example.com/pr/123">
+          Go to pull request #123
+        </option>
+        <option value="https://docs.readthedocs.com/platform/stable/visual-diff.html">
+          Go to Visual Diff documentation
         </option>
       </optgroup>
     </select>
@@ -53,7 +64,7 @@ snapshots["Filetreediff tests toggle Show diff checkbox"] =
         selected=""
         value=""
       >
-        Files changed
+        Files changed in #123
       </option>
       <optgroup label="Added">
         <option value="http://project.readthedocs.io/en/latest/testing.html">
@@ -63,6 +74,17 @@ snapshots["Filetreediff tests toggle Show diff checkbox"] =
       <optgroup label="Changed">
         <option value="http://project.readthedocs.io/en/latest/commercial.html">
           ± commercial.html
+        </option>
+      </optgroup>
+      <optgroup label="Links">
+        <option value="http://example.com/build/456?utm_source=project&amp;utm_content=notification">
+          Go to build log
+        </option>
+        <option value="http://example.com/pr/123">
+          Go to pull request #123
+        </option>
+        <option value="https://docs.readthedocs.com/platform/stable/visual-diff.html">
+          Go to Visual Diff documentation
         </option>
       </optgroup>
     </select>

--- a/tests/filetreediff.test.html
+++ b/tests/filetreediff.test.html
@@ -18,6 +18,18 @@
             versions: {
               current: {
                 type: "external",
+                slug: "123",
+                urls: {
+                  vcs: "http://example.com/pr/123",
+                },
+              },
+            },
+            builds: {
+              current: {
+                pk: "456",
+                urls: {
+                  build: "http://example.com/build/456",
+                },
               },
             },
             addons: {

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -280,7 +280,6 @@
             // The notification should not be displayed
             expect(element).shadowDom.to.equal("");
           });
-
         });
       });
     </script>

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -222,22 +222,6 @@
             expect(element).shadowDom.to.equal("");
           });
 
-          it("on external version", async () => {
-            config.versions.current.slug = "381";
-            config.versions.current.type = "external";
-
-            const addon = new notification.NotificationAddon(config);
-            const element = document.querySelector("readthedocs-notification");
-
-            // We need to wait for the element to renders/updates before querying it
-            await elementUpdated(element);
-
-            const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
-              "This page was created from a pull request build",
-            );
-          });
-
           it("check default CSS classes", async () => {
             const addon = new notification.NotificationAddon(config);
             const element = document.querySelector("readthedocs-notification");
@@ -297,31 +281,6 @@
             expect(element).shadowDom.to.equal("");
           });
 
-          it("renders when a different version was previously closed", async () => {
-            config.versions.current.slug = "381";
-            config.versions.current.type = "external";
-
-            // localStorage should contain information about the previous dismissal
-            const addonInformation = {
-              "project-en-v1.0-notification": { dismissedTimestamp: 123 },
-            };
-            const localStorageString = JSON.stringify(addonInformation);
-            getLocalStorageStub
-              .withArgs("readthedocs-notification-storage-key")
-              .returns(localStorageString);
-
-            const addon = new notification.NotificationAddon(config);
-            const element = document.querySelector("readthedocs-notification");
-
-            // We need to wait for the element to renders/updates before querying it
-            await elementUpdated(element);
-
-            // The notification should be displayed normally
-            const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
-              "This page was created from a pull request build",
-            );
-          });
         });
       });
     </script>


### PR DESCRIPTION
This removes the PR build notification,
and includes some information in the Visual Diff UI with similar information.


I tested with a real version, but these would be PR #'s in normal usage:

![Screenshot 2025-02-19 at 3 48 39 PM](https://github.com/user-attachments/assets/37e66515-4b4c-4ebf-a434-6a581838106d)

Refs https://github.com/readthedocs/meta/issues/176