### PR TITLE
Notification: render it inline using `docTool.getRootSelector()`

### DIFF
--- a/src/doctools.css
+++ b/src/doctools.css
@@ -22,6 +22,10 @@
     --readthedocs-notification-font-size: 0.8rem;
   }
 
+  :root[data-readthedocs-tool="jekyll"] {
+    --readthedocs-notification-font-size: 0.9rem;
+  }
+
   :root[data-readthedocs-tool="mkdocs-material"] {
     --readthedocs-font-size: 0.65rem;
     --readthedocs-flyout-header-font-size: 0.75rem;

--- a/src/doctools.css
+++ b/src/doctools.css
@@ -7,13 +7,27 @@
  **/
 @layer defaults {
   :root[data-readthedocs-tool="docusaurus"] {
-    --readthedocs-flyout-header-font-size: 0.9rem;
+    --readthedocs-flyout-header-font-size: 0.95rem;
+  }
+
+  :root[data-readthedocs-tool="docsify"] {
+    --readthedocs-notification-font-size: 0.95rem;
+  }
+
+  :root[data-readthedocs-tool="asciidoctor"] {
+    --readthedocs-notification-font-size: 0.95rem;
+  }
+
+  :root[data-readthedocs-tool="antora"] {
+    --readthedocs-notification-font-size: 0.8rem;
   }
 
   :root[data-readthedocs-tool="mkdocs-material"] {
-    --readthedocs-font-size: 0.58rem;
-    --readthedocs-flyout-header-font-size: 0.7rem;
-    --readthedocs-flyout-font-size: 0.58rem;
+    --readthedocs-font-size: 0.65rem;
+    --readthedocs-flyout-header-font-size: 0.75rem;
+    --readthedocs-flyout-font-size: 0.65rem;
+
+    --readthedocs-notification-font-size: 0.75rem;
   }
 
   :root[data-readthedocs-tool="antora"] {
@@ -29,14 +43,20 @@
   }
 
   :root[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="furo"] {
-    --readthedocs-font-size: 0.725rem;
-    --readthedocs-flyout-header-font-size: 0.845rem;
-    --readthedocs-flyout-font-size: 0.725rem;
+    --readthedocs-font-size: 0.9rem;
+    --readthedocs-flyout-header-font-size: 0.9rem;
+    --readthedocs-flyout-font-size: 0.8rem;
+
+    --readthedocs-notification-font-size: 0.9rem;
   }
 
   :root[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="immaterial"] {
     --readthedocs-font-size: 0.58rem;
     --readthedocs-flyout-header-font-size: 0.7rem;
     --readthedocs-flyout-font-size: 0.58rem;
+  }
+
+  :root[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="alabaster"] {
+    --readthedocs-notification-font-size: 0.9rem;
   }
 }

--- a/src/doctools.css
+++ b/src/doctools.css
@@ -57,6 +57,7 @@
   }
 
   :root[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="alabaster"] {
+    --readthedocs-flyout-header-font-size: 0.95rem;
     --readthedocs-notification-font-size: 0.9rem;
   }
 }

--- a/src/notification.js
+++ b/src/notification.js
@@ -47,6 +47,7 @@ export class NotificationElement extends LitElement {
     this.localStorageKey = null;
     this.dismissedTimestamp = null;
     this.autoDismissed = false;
+    this.autoDismissEnabled = true;
 
     // Trigger the auto-dismiss timer at startup
     this.triggerAutoDismissTimer();
@@ -66,7 +67,7 @@ export class NotificationElement extends LitElement {
   }
 
   triggerAutoDismissTimer() {
-    if (!document.hidden && !this.autoDismissed) {
+    if (this.autoDismissEnabled && !document.hidden && !this.autoDismissed) {
       clearTimeout(this.timerID);
       this.timerID = setTimeout(() => {
         this.autoDismissed = true;
@@ -414,6 +415,15 @@ export class NotificationAddon extends AddonBase {
   static addonEnabledPath = "addons.notifications.enabled";
   static addonName = "Notification";
   static elementClass = NotificationElement;
+  static elementInjectBehavior = "prepend";
+
+  setupInitialBehavior() {
+    for (const element of this.elements) {
+      element.autoDismissEnabled = false;
+      element.clearAutoDismissTimer();
+      element.className = "raised";
+    }
+  }
 }
 
 customElements.define(NotificationElement.elementName, NotificationElement);

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,10 +99,11 @@ export class AddonBase {
 
         const injectBehavior = this.constructor.elementInjectBehavior;
         const selector = this.getElementInjectSelector();
-        const elementSelector = document.querySelector(selector);
+        const elementSelector =
+          document.querySelector(selector) || document.querySelector("body");
 
         // Setup the initial behavior only if we are using a custom position for it.
-        if (selector !== "body") {
+        if (elementSelector.tagName.toLocaleLowerCase() !== "body") {
           this.setupInitialBehavior();
         }
 


### PR DESCRIPTION
Instead of rendering the notification floating at the top right, we use the heuristic from `DocumentationTool` class to get the root selector and we prepend the notification WebComponent there.

## Example

Small example showing how it behaves with some of the known generators.

[Peek 2025-02-20 12-25.webm](https://github.com/user-attachments/assets/6a50daee-8920-4835-a42f-29d42aa49570)

## ToDo

- [ ] ~Tweaks selectors -- we may want a different selector than the root one, specific for this use case. I'm not sure.~ I started writing this code, but It seems it's not needed for now.
- [x] Add style rules to some doctools to render accordingly.
- [ ] Write some tests.
- [ ] Feedback from the team.


Closes #550