### PR TITLE
Event: not trigger URL changed when `readthedocs-*` params changed

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -235,6 +235,9 @@ export function setupHistoryEvents() {
           //
           // import { DOCDIFF_URL_PARAM } from "./docdiff";
           toURL.searchParams.delete("readthedocs-diff");
+          toURL.searchParams.delete("readthedocs-diff-chunk");
+          fromURL.searchParams.delete("readthedocs-diff");
+          fromURL.searchParams.delete("readthedocs-diff-chunk");
 
           // Dispatch the event only if the new URL is not just the DOCDIFF_URL_PARAM added.
           if (toURL.href !== fromURL.href) {


### PR DESCRIPTION
Small fix to the current logic.