### PR TITLE
Use footer text content ad for unknown themes

### DIFF
--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -196,18 +196,18 @@ export class EthicalAdsAddon extends AddonBase {
         if (elementToAppend) {
           elementToAppend.append(placement);
         }
-      } else if (window.innerWidth > 1300) {
-        // https://ethical-ad-client.readthedocs.io/en/latest/#stickybox
-        placement.setAttribute("data-ea-type", "image");
-        placement.setAttribute("data-ea-style", "stickybox");
-        this.addEaPlacementToElement(placement);
-        // `document.body` here is not too much relevant, since we are going to
-        // use this selector only for a floating stickybox ad
-        const elementInsertBefore = document.body;
-        elementInsertBefore.insertBefore(
-          placement,
-          elementInsertBefore.lastChild,
-        );
+      } else {
+        // Default to a text ad appended to the root selector when no known placement found
+        placement.setAttribute("data-ea-type", "text");
+
+        const rootSelector = docTool.getRootSelector();
+        const rootElement = document.querySelector(rootSelector);
+
+        if (rootElement) {
+          rootElement.append(placement);
+        } else {
+          console.debug("Could not find root element to append ad");
+        }
       }
     }
 


### PR DESCRIPTION
This is much less intrusive than the stickybox,
and allows us to still have an ad injected,
but not cover the content for users when this happens.
