### PR TITLE
Remove PR build warning

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -3,7 +3,6 @@ import { library, icon } from "@fortawesome/fontawesome-svg-core";
 import {
   faCircleXmark,
   faFlask,
-  faCodePullRequest,
   faHourglassHalf,
 } from "@fortawesome/free-solid-svg-icons";
 import { html, nothing, render, LitElement } from "lit";
@@ -198,18 +197,6 @@ export class NotificationElement extends LitElement {
       return nothing;
     }
 
-    if (this.config.versions.current.type === "external") {
-      if (
-        objectPath.get(
-          this.config,
-          "addons.notifications.show_on_external",
-          false,
-        )
-      ) {
-        return this.renderExternalVersionWarning();
-      }
-    }
-
     if (
       this.readingLatestVersion &&
       this.stableVersionAvailable &&
@@ -329,35 +316,6 @@ export class NotificationElement extends LitElement {
           <a href="${this.urls.stable}"
             >latest stable version of this documentation</a
           >.
-        </div>
-      </div>
-    `;
-  }
-
-  renderExternalVersionWarning() {
-    library.add(faCodePullRequest);
-    const iconPullRequest = icon(faCodePullRequest, {
-      title: "This version is a pull request version",
-      classes: ["header", "icon"],
-    });
-
-    return html`
-      <div>
-        ${iconPullRequest.node[0]}
-        <div class="title">
-          This page was created from a pull request build
-          ${this.renderCloseButton()}
-        </div>
-        <div class="content">
-          See the
-          <a href="${addUtmParameters(this.urls.build, "notification")}"
-            >build's detail page</a
-          >
-          or
-          <a href="${this.urls.external}"
-            >pull request #${this.config.versions.current.slug}</a
-          >
-          for more information.
         </div>
       </div>
     `;

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -222,22 +222,6 @@
             expect(element).shadowDom.to.equal("");
           });
 
-          it("on external version", async () => {
-            config.versions.current.slug = "381";
-            config.versions.current.type = "external";
-
-            const addon = new notification.NotificationAddon(config);
-            const element = document.querySelector("readthedocs-notification");
-
-            // We need to wait for the element to renders/updates before querying it
-            await elementUpdated(element);
-
-            const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
-              "This page was created from a pull request build",
-            );
-          });
-
           it("check default CSS classes", async () => {
             const addon = new notification.NotificationAddon(config);
             const element = document.querySelector("readthedocs-notification");
@@ -295,32 +279,6 @@
 
             // The notification should not be displayed
             expect(element).shadowDom.to.equal("");
-          });
-
-          it("renders when a different version was previously closed", async () => {
-            config.versions.current.slug = "381";
-            config.versions.current.type = "external";
-
-            // localStorage should contain information about the previous dismissal
-            const addonInformation = {
-              "project-en-v1.0-notification": { dismissedTimestamp: 123 },
-            };
-            const localStorageString = JSON.stringify(addonInformation);
-            getLocalStorageStub
-              .withArgs("readthedocs-notification-storage-key")
-              .returns(localStorageString);
-
-            const addon = new notification.NotificationAddon(config);
-            const element = document.querySelector("readthedocs-notification");
-
-            // We need to wait for the element to renders/updates before querying it
-            await elementUpdated(element);
-
-            // The notification should be displayed normally
-            const title = element.shadowRoot.querySelector("div.title");
-            expect(title.innerText).to.be.equal(
-              "This page was created from a pull request build",
-            );
           });
         });
       });


### PR DESCRIPTION
The Files Changed UI solves this problem in a much nicer way.
I think we can get rid of this warning,
since it's just in the way now.
