### PR TITLE
CSS: update default styles

### DIFF
--- a/src/defaults.css
+++ b/src/defaults.css
@@ -6,11 +6,12 @@
   }
 
   :root[data-readthedocs-tool="mkdocs-material"] {
-    --readthedocs-font-size: 0.58rem;
+    --readthedocs-font-size: 1.455em;
   }
 
   :root[data-readthedocs-tool="antora"] {
-    --readthedocs-font-size: 0.7rem;
+    --readthedocs-flyout-font-size: 0.7em;
+    --readthedocs-notification-font-size: 0.75em;
   }
 
   :root[data-readthedocs-tool="mdbook"] {
@@ -18,10 +19,10 @@
   }
 
   :root[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="furo"] {
-    --readthedocs-font-size: 0.725rem;
+    --readthedocs-font-size: 0.9em;
   }
 
   :root[data-readthedocs-tool="sphinx"][data-readthedocs-tool-theme="immaterial"] {
-    --readthedocs-font-size: 0.58rem;
+    --readthedocs-font-size: 1.45em;
   }
 }

--- a/src/notification.css
+++ b/src/notification.css
@@ -1,11 +1,9 @@
 @layer defaults {
   :root {
-    --readthedocs-notification-font-size: var(--readthedocs-font-size);
-    --readthedocs-notification-font-family: var(--readthedocs-font-family);
-
-    --readthedocs-notification-toast-font-size: calc(
-      var(--readthedocs-notification-font-size) * 0.85
+    --readthedocs-notification-font-size: calc(
+      var(--readthedocs-font-size) * 0.85
     );
+    --readthedocs-notification-font-family: var(--readthedocs-font-family);
 
     --readthedocs-notification-color: rgb(64, 64, 64);
     --readthedocs-notification-background-color: rgb(234, 234, 234);
@@ -51,7 +49,6 @@
   top: 2rem;
   right: 2rem;
   z-index: 1750;
-  font-size: var(--readthedocs-notification-toast-font-size);
   width: 35rem;
   max-width: calc(100vw - 4rem);
 }
@@ -114,7 +111,6 @@
 }
 :host > div > div.content {
   line-height: 1em;
-  font-size: 0.85em;
   padding: 0 1.5em;
 }
 


### PR DESCRIPTION
I took the time to review all the themes listed in https://readthedocs-addons.readthedocs.io/ and I added the modifications required to make them to look exactly as they were before.

I also opened two issues that I found while doing this, but they are unrelated to this particular change:

* https://github.com/readthedocs/addons/issues/588
* https://github.com/readthedocs/addons/issues/589

Closes #586