### PR TITLE
Docs: replace typlog by shibuya

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ We maintain a list of examples to check our JavaScript client is working correct
 * `Sphinx (Immaterial theme) <https://test-builds.readthedocs.io/en/immaterial-theme/>`_
 * `Sphinx (PyData theme) <https://test-builds.readthedocs.io/en/pydata-theme/>`_
 * `Sphinx (Read the Docs theme) <https://test-builds.readthedocs.io/en/latest/>`_
-* `Sphinx (Typlog theme) <https://test-builds.readthedocs.io/en/typlog-theme/>`_
+* `Sphinx (Shibuya theme) <https://test-builds.readthedocs.io/en/shibuya-theme/>`_
 * `VitePress <https://test-builds.readthedocs.io/en/vitepress/>`_
 
 


### PR DESCRIPTION
Typlog is archived and Shibuya is the new fancy version of it.