### PR TITLE
VisualDiff: complex selector and `?maincontent=` API argument

### DIFF
--- a/src/docdiff.js
+++ b/src/docdiff.js
@@ -186,9 +186,21 @@ export class DocDiffElement extends LitElement {
   performDiff(remoteContent) {
     const parser = new DOMParser();
     const htmlDocument = parser.parseFromString(remoteContent, "text/html");
-    const oldBody = htmlDocument.documentElement.querySelector(
-      this.rootSelector,
-    );
+
+    // We first try to get the `rootSelector` from the `remoteContent`.
+    // However, depending on how the selector is constructed, it may not exist
+    // even if the response is valid.
+    //
+    // This happens when we send `?maincontent=` to the API backend with a
+    // complex selector (eg. "main > div > div.md-content") since in the
+    // response the first elements (e.g. "main > div") won't exist because the
+    // content is already parsed to return only the `?maincontent=` selector.
+    //
+    // In those cases, we always pick the `firstElementChild` of the body.
+    const oldBody =
+      htmlDocument.documentElement.querySelector(this.rootSelector) ||
+      htmlDocument.documentElement.querySelector("body").firstElementChild;
+
     const newBody = document.querySelector(this.rootSelector);
 
     if (oldBody === null) {


### PR DESCRIPTION
When we send the `?maincontent=` CSS selector to the API endpoint, the response file is chunked to only return the chunk that contains the CSS selector.

There are cases when we use inner CSS selector that won't work on the returned response (eg. `main > div > div.md-content`) since the response will contain only the `<div class="md-content">...` part.

In those cases, the query for `this.rootSelector` will fail and we will fallback to the `document.body.firstElementChild` which will always be the element we are looking for.

Unfortunately, I wasn't able to write a test case for this. I've tried different approaches and wasn't able to :/

Closes #576