### PR TITLE
Remove project downloads URL from validation

### DIFF
--- a/public/_/readthedocs-addons.json
+++ b/public/_/readthedocs-addons.json
@@ -18,7 +18,7 @@
         "documentation": "http://localhost:8000/en/v1.0/",
         "home": "https://devthedocs.org/projects/example/",
         "builds": "https://devthedocs.org/projects/example/builds/",
-        "downloads": "https://devthedocs.org/projects/example/downloads/"
+        "downloads": null
       }
     },
     "translations": [

--- a/src/data-validation.js
+++ b/src/data-validation.js
@@ -167,11 +167,10 @@ const addons_flyout = {
             slug: { type: "string" },
             urls: {
               type: "object",
-              required: ["home", "builds", "downloads"],
+              required: ["home", "builds"],
               properties: {
                 home: { type: "string" },
                 builds: { type: "string" },
-                downloads: { type: "string" },
               },
             },
             versioning_scheme: {


### PR DESCRIPTION
This is now a `null` response, and is no longer a string/URL. This was
resulting in silent failures of addons flyout injection.