### PR TITLE
Visual diff: use default CSS variables for Material for MkDocs

### DIFF
--- a/src/defaults.css
+++ b/src/defaults.css
@@ -7,6 +7,7 @@
 
   :root[data-readthedocs-tool="mkdocs-material"] {
     --readthedocs-font-size: 1.455em;
+    --readthedocs-filetreediff-icon-width: 0.6rem;
   }
 
   :root[data-readthedocs-tool="antora"] {

--- a/src/filetreediff.css
+++ b/src/filetreediff.css
@@ -10,6 +10,7 @@
     --readthedocs-filetreediff-border-color: #ddd;
     --readthedocs-filetreediff-label-color: #333;
     --readthedocs-filetreediff-chunks-color: #27ae60;
+    --readthedocs-filetreediff-icon-width: 0.8rem;
   }
 }
 
@@ -41,7 +42,6 @@
   background-color: var(--readthedocs-filetreediff-background-color);
   border-radius: 0.25em;
   appearance: revert;
-  font-size: var(--readthedocs-filetreediff-font-size);
 }
 
 :host > div > div > label {
@@ -70,8 +70,8 @@
 }
 
 :host > div > div > a {
-  width: 0.8rem;
-  color: var(--addons-filetreediff-color);
+  width: var(--readthedocs-filetreediff-icon-width);
+  color: var(--readthedocs-filetreediff-color);
 }
 
 :host > div > div > a.version {


### PR DESCRIPTION
![Screenshot_2025-06-30_13-51-21](https://github.com/user-attachments/assets/b756fb30-29d1-44b0-9fb0-fdfdd1f13432)

Closes #505