### PR TITLE
Search: filters enabled by default

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -111,6 +111,7 @@ export class SearchElement extends LitElement {
         userFilters.push({
           name: filter[0],
           value: filter[1],
+          default: filter[2],
         });
       }
       this.filters = userFilters;
@@ -239,6 +240,7 @@ export class SearchElement extends LitElement {
                   id="filter-${index}"
                   type="checkbox"
                   value="${filter.value}"
+                  ?checked=${filter.default}
                 />
                 <label for="filter-${index}"> ${filter.name} </label>
               </li>


### PR DESCRIPTION
Read the addons API and enable/disable the filters by default based on that data. This is an initial and immediate simple solution for #22 without implementing all the features.

Basically, all projects that have subprojects will now have "Include subprojects" checked by default. In the future, we will allow users to enable/disable this per project.