### PR TITLE
Fix issue with null current build validation

### DIFF
--- a/src/data-validation.js
+++ b/src/data-validation.js
@@ -369,7 +369,7 @@ const addons_notifications = {
       required: ["current"],
       properties: {
         current: {
-          type: "object",
+          type: ["object", "null"],
           required: ["urls"],
           properties: {
             urls: {

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -241,7 +241,8 @@
           it("handles null current build", async () => {
             config.builds.current = null;
 
-            expect(notification.NotificationAddon.isConfigValid(config)).to.be.true;
+            expect(notification.NotificationAddon.isConfigValid(config)).to.be
+              .true;
           });
 
           it("check default CSS classes", async () => {

--- a/tests/notification.test.html
+++ b/tests/notification.test.html
@@ -238,6 +238,12 @@
             );
           });
 
+          it("handles null current build", async () => {
+            config.builds.current = null;
+
+            expect(notification.NotificationAddon.isConfigValid(config)).to.be.true;
+          });
+
           it("check default CSS classes", async () => {
             const addon = new notification.NotificationAddon(config);
             const element = document.querySelector("readthedocs-notification");


### PR DESCRIPTION
When a project is private and version private the current build can be null. This was presenting as an exception in validation, especially for the notification addon.