### PR TITLE
EthicalAd: fixed footer placement for specific themes

### DIFF
--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -44,8 +44,7 @@ export class EthicalAdsAddon extends AddonBase {
 
   createAdPlacement() {
     let placement;
-    const docToolName = docTool.getDocumentationTool();
-    const placementIdSuffix = docToolName ? `${docToolName}` : "unknown";
+    const placementIdSuffix = docTool.getDocumentationTool() || "nodoctool";
 
     // TODO: fix this on testing. It works fine on production/regular browser.
     // TypeError: Failed to execute 'indexed value' on 'ObservableArray<CSSStyleSheet>': Failed to convert value to 'CSSStyleSheet'.
@@ -262,14 +261,18 @@ export class EthicalAdsAddon extends AddonBase {
         );
       }
 
-      // Set a standardized id attribute
-      const placementStyle = placement.getAttribute("data-ea-style");
-      const placementType = placement.getAttribute("data-ea-type");
-      const placementIdPrefix = `${placementType}-${placementStyle}`;
-      placement.setAttribute(
-        "id",
-        `readthedocs-ea-${placementIdPrefix}-${placementIdSuffix}`,
-      );
+      if (!placement.getAttribute("id")) {
+        // Set a standardized id attribute
+        const placementStyle =
+          placement.getAttribute("data-ea-style") || "nostyle";
+        const placementType =
+          placement.getAttribute("data-ea-type") || "notype";
+        const placementIdPrefix = `${placementType}-${placementStyle}`;
+        placement.setAttribute(
+          "id",
+          `readthedocs-ea-${placementIdPrefix}-${placementIdSuffix}`,
+        );
+      }
     }
 
     return placement;

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -99,6 +99,16 @@ export class EthicalAdsAddon extends AddonBase {
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
           placement.setAttribute("id", "furo-sidebar-ad-placement");
           knownPlacementFound = true;
+        } else {
+          // We know it's furo theme and the ad in the navbar is not above the fold at this point.
+          // Then, we render the ad as fixed footer.
+          selector = "div.page";
+          element = document.querySelector(selector);
+          element.style.setProperty("padding-bottom", "47.2px");
+          placement.setAttribute("data-ea-type", "text");
+          placement.setAttribute("data-ea-style", "fixedfooter");
+          placement.setAttribute("id", "furo-fixed-footer-ad-placement");
+          knownPlacementFound = true;
         }
       } else if (docTool.isSphinxBookThemeLikeTheme()) {
         selector = ".sidebar-primary-items__start.sidebar-primary__section";
@@ -130,6 +140,20 @@ export class EthicalAdsAddon extends AddonBase {
           placement.classList.add("ethical-alabaster");
 
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
+          knownPlacementFound = true;
+        } else {
+          // We know it's Material for MkDocs theme and the ad in the navbar
+          // is not above the fold at this point. Then, we render the ad as
+          // fixed footer.
+          selector = "div.md-container";
+          element = document.querySelector(selector);
+          element.style.setProperty("padding-bottom", "47.2px");
+          placement.setAttribute("data-ea-type", "text");
+          placement.setAttribute("data-ea-style", "fixedfooter");
+          placement.setAttribute(
+            "id",
+            "mkdocs-material-fixed-footer-ad-placement",
+          );
           knownPlacementFound = true;
         }
       } else if (docTool.isDocusaurusTheme()) {

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -88,12 +88,7 @@ export class EthicalAdsAddon extends AddonBase {
           // We know it's RTD theme and the ad in the navbar is not above the fold at this point.
           // Then, we render the ad as fixed footer.
           const selectors = ["section", "nav"];
-          for (selector of selectors) {
-            element = document.querySelector(selector);
-            element.style.setProperty("padding-bottom", "47.2px");
-          }
-          placement.setAttribute("data-ea-type", "text");
-          placement.setAttribute("data-ea-style", "fixedfooter");
+          this.injectFixedFooterAd(selectors, placement);
           knownPlacementFound = true;
         }
       } else if (docTool.isSphinxFuroLikeTheme()) {
@@ -112,11 +107,8 @@ export class EthicalAdsAddon extends AddonBase {
         } else {
           // We know it's furo theme and the ad in the navbar is not above the fold at this point.
           // Then, we render the ad as fixed footer.
-          selector = "div.page";
-          element = document.querySelector(selector);
-          element.style.setProperty("padding-bottom", "47.2px");
-          placement.setAttribute("data-ea-type", "text");
-          placement.setAttribute("data-ea-style", "fixedfooter");
+          const selectors = ["div.page"];
+          this.injectFixedFooterAd(selectors, placement);
           knownPlacementFound = true;
         }
       } else if (docTool.isSphinxBookThemeLikeTheme()) {
@@ -154,11 +146,8 @@ export class EthicalAdsAddon extends AddonBase {
           // We know it's Material for MkDocs theme and the ad in the navbar
           // is not above the fold at this point. Then, we render the ad as
           // fixed footer.
-          selector = "div.md-container";
-          element = document.querySelector(selector);
-          element.style.setProperty("padding-bottom", "47.2px");
-          placement.setAttribute("data-ea-type", "text");
-          placement.setAttribute("data-ea-style", "fixedfooter");
+          const selectors = ["div.md-container"];
+          this.injectFixedFooterAd(selectors, placement);
           knownPlacementFound = true;
         }
       } else if (docTool.isDocusaurusTheme()) {
@@ -175,11 +164,9 @@ export class EthicalAdsAddon extends AddonBase {
           placement.setAttribute("data-ea-style", "image");
           knownPlacementFound = true;
         } else {
-          selector = "div#__docusaurus";
-          element = document.querySelector(selector);
-          element.style.setProperty("padding-bottom", "47.2px");
-          placement.setAttribute("data-ea-type", "text");
-          placement.setAttribute("data-ea-style", "fixedfooter");
+          const selectors = ["div#__docusaurus"];
+          this.injectFixedFooterAd(selectors, placement);
+
           knownPlacementFound = true;
         }
       } else if (docTool.isDocsify()) {
@@ -313,6 +300,15 @@ export class EthicalAdsAddon extends AddonBase {
     }
 
     return true;
+  }
+
+  injectFixedFooterAd(selectors, placement) {
+    for (const selector of selectors) {
+      const element = document.querySelector(selector);
+      element.style.setProperty("padding-bottom", "47.2px");
+    }
+    placement.setAttribute("data-ea-type", "text");
+    placement.setAttribute("data-ea-style", "fixedfooter");
   }
 
   addEaPlacementToElement(element) {

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -44,6 +44,8 @@ export class EthicalAdsAddon extends AddonBase {
 
   createAdPlacement() {
     let placement;
+    const docToolName = docTool.getDocumentationTool();
+    const placementIdSuffix = docToolName ? `${docToolName}` : "unknown";
 
     // TODO: fix this on testing. It works fine on production/regular browser.
     // TypeError: Failed to execute 'indexed value' on 'ObservableArray<CSSStyleSheet>': Failed to convert value to 'CSSStyleSheet'.
@@ -67,7 +69,6 @@ export class EthicalAdsAddon extends AddonBase {
     } else {
       // Inject our own floating element
       placement = document.createElement("div");
-      placement.setAttribute("id", "readthedocs-ea");
       placement.classList.add("raised");
 
       // Define where to inject the Ad based on the theme and if it's above the fold or not.
@@ -97,7 +98,6 @@ export class EthicalAdsAddon extends AddonBase {
         if (this.elementAboveTheFold(element)) {
           placement.classList.add("ethical-alabaster");
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
-          placement.setAttribute("id", "furo-sidebar-ad-placement");
           knownPlacementFound = true;
         } else {
           // We know it's furo theme and the ad in the navbar is not above the fold at this point.
@@ -107,7 +107,6 @@ export class EthicalAdsAddon extends AddonBase {
           element.style.setProperty("padding-bottom", "47.2px");
           placement.setAttribute("data-ea-type", "text");
           placement.setAttribute("data-ea-style", "fixedfooter");
-          placement.setAttribute("id", "furo-fixed-footer-ad-placement");
           knownPlacementFound = true;
         }
       } else if (docTool.isSphinxBookThemeLikeTheme()) {
@@ -150,10 +149,6 @@ export class EthicalAdsAddon extends AddonBase {
           element.style.setProperty("padding-bottom", "47.2px");
           placement.setAttribute("data-ea-type", "text");
           placement.setAttribute("data-ea-style", "fixedfooter");
-          placement.setAttribute(
-            "id",
-            "mkdocs-material-fixed-footer-ad-placement",
-          );
           knownPlacementFound = true;
         }
       } else if (docTool.isDocusaurusTheme()) {
@@ -175,7 +170,6 @@ export class EthicalAdsAddon extends AddonBase {
           element.style.setProperty("padding-bottom", "47.2px");
           placement.setAttribute("data-ea-type", "text");
           placement.setAttribute("data-ea-style", "fixedfooter");
-          placement.setAttribute("id", "docusaurus-fixed-footer-ad-placement");
           knownPlacementFound = true;
         }
       } else if (docTool.isDocsify()) {
@@ -233,11 +227,6 @@ export class EthicalAdsAddon extends AddonBase {
       } else {
         // Default to a text ad appended to the root selector when no known placement found
         placement.setAttribute("data-ea-type", "text");
-        // TODO: Check this placement on the dashboard,
-        // and see how this is performing.
-        const docToolName = docTool.getDocumentationTool();
-        const idSuffix = docToolName ? `-${docToolName}` : "";
-        placement.setAttribute("id", `readthedocs-ea-text-footer${idSuffix}`);
 
         const rootSelector = docTool.getRootSelector();
         const rootElement = document.querySelector(rootSelector);
@@ -272,6 +261,15 @@ export class EthicalAdsAddon extends AddonBase {
           campaign_types.join("|"),
         );
       }
+
+      // Set a standardized id attribute
+      const placementStyle = placement.getAttribute("data-ea-style");
+      const placementType = placement.getAttribute("data-ea-type");
+      const placementIdPrefix = `${placementType}-${placementStyle}`;
+      placement.setAttribute(
+        "id",
+        `readthedocs-ea-${placementIdPrefix}-${placementIdSuffix}`,
+      );
     }
 
     return placement;

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -88,7 +88,7 @@ export class EthicalAdsAddon extends AddonBase {
           // We know it's RTD theme and the ad in the navbar is not above the fold at this point.
           // Then, we render the ad as fixed footer.
           const selectors = ["section", "nav"];
-          this.injectFixedFooterAd(selectors, placement);
+          this.setFixedFooterAdProperties(selectors, placement);
           knownPlacementFound = true;
         }
       } else if (docTool.isSphinxFuroLikeTheme()) {
@@ -108,7 +108,7 @@ export class EthicalAdsAddon extends AddonBase {
           // We know it's furo theme and the ad in the navbar is not above the fold at this point.
           // Then, we render the ad as fixed footer.
           const selectors = ["div.page"];
-          this.injectFixedFooterAd(selectors, placement);
+          this.setFixedFooterAdProperties(selectors, placement);
           knownPlacementFound = true;
         }
       } else if (docTool.isSphinxBookThemeLikeTheme()) {
@@ -147,7 +147,7 @@ export class EthicalAdsAddon extends AddonBase {
           // is not above the fold at this point. Then, we render the ad as
           // fixed footer.
           const selectors = ["div.md-container"];
-          this.injectFixedFooterAd(selectors, placement);
+          this.setFixedFooterAdProperties(selectors, placement);
           knownPlacementFound = true;
         }
       } else if (docTool.isDocusaurusTheme()) {
@@ -165,7 +165,7 @@ export class EthicalAdsAddon extends AddonBase {
           knownPlacementFound = true;
         } else {
           const selectors = ["div#__docusaurus"];
-          this.injectFixedFooterAd(selectors, placement);
+          this.setFixedFooterAdProperties(selectors, placement);
 
           knownPlacementFound = true;
         }
@@ -302,7 +302,7 @@ export class EthicalAdsAddon extends AddonBase {
     return true;
   }
 
-  injectFixedFooterAd(selectors, placement) {
+  setFixedFooterAdProperties(selectors, placement) {
     for (const selector of selectors) {
       const element = document.querySelector(selector);
       element.style.setProperty("padding-bottom", "47.2px");

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -106,12 +106,6 @@ export class EthicalAdsAddon extends AddonBase {
           placement.classList.add("ethical-alabaster");
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
           knownPlacementFound = true;
-        } else {
-          // We know it's furo theme and the ad in the navbar is not above the fold at this point.
-          // Then, we render the ad as fixed footer.
-          selectors = ["div.page"];
-          this.setFixedFooterAdProperties(selectors, placement);
-          knownPlacementFound = true;
         }
       } else if (docTool.isSphinxBookThemeLikeTheme()) {
         selector = ".sidebar-primary-items__start.sidebar-primary__section";
@@ -144,13 +138,6 @@ export class EthicalAdsAddon extends AddonBase {
 
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
           knownPlacementFound = true;
-        } else {
-          // We know it's Material for MkDocs theme and the ad in the navbar
-          // is not above the fold at this point. Then, we render the ad as
-          // fixed footer.
-          selectors = ["div.md-container"];
-          this.setFixedFooterAdProperties(selectors, placement);
-          knownPlacementFound = true;
         }
       } else if (docTool.isDocusaurusTheme()) {
         selector = ".menu.thin-scrollbar.menu_SIkG";
@@ -164,11 +151,6 @@ export class EthicalAdsAddon extends AddonBase {
 
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
           placement.setAttribute("data-ea-style", "image");
-          knownPlacementFound = true;
-        } else {
-          selectors = ["div#__docusaurus"];
-          this.setFixedFooterAdProperties(selectors, placement);
-
           knownPlacementFound = true;
         }
       } else if (docTool.isDocsify()) {

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -84,6 +84,17 @@ export class EthicalAdsAddon extends AddonBase {
           placement.classList.add("ethical-rtd");
           placement.classList.add("ethical-dark-theme");
           knownPlacementFound = true;
+        } else {
+          // We know it's RTD theme and the ad in the navbar is not above the fold at this point.
+          // Then, we render the ad as fixed footer.
+          const selectors = ["section", "nav"];
+          for (selector of selectors) {
+            element = document.querySelector(selector);
+            element.style.setProperty("padding-bottom", "47.2px");
+          }
+          placement.setAttribute("data-ea-type", "text");
+          placement.setAttribute("data-ea-style", "fixedfooter");
+          knownPlacementFound = true;
         }
       } else if (docTool.isSphinxFuroLikeTheme()) {
         // NOTE: The code to handle furo theme shouldn't be required,

--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -169,6 +169,14 @@ export class EthicalAdsAddon extends AddonBase {
           placement.setAttribute("data-ea-type", "readthedocs-sidebar");
           placement.setAttribute("data-ea-style", "image");
           knownPlacementFound = true;
+        } else {
+          selector = "div#__docusaurus";
+          element = document.querySelector(selector);
+          element.style.setProperty("padding-bottom", "47.2px");
+          placement.setAttribute("data-ea-type", "text");
+          placement.setAttribute("data-ea-style", "fixedfooter");
+          placement.setAttribute("id", "docusaurus-fixed-footer-ad-placement");
+          knownPlacementFound = true;
         }
       } else if (docTool.isDocsify()) {
         selector = "main > aside > div.sidebar-nav";

--- a/tests/__snapshots__/ethicalads.test.snap.js
+++ b/tests/__snapshots__/ethicalads.test.snap.js
@@ -13,7 +13,7 @@ snapshots["EthicalAd addon ad placement defined by the user"] = `<div
 </div>
 `;
 /* end snapshot EthicalAd addon ad placement defined by the user */
-snapshots["EthicalAd addon ad placement injected"] = 
+snapshots["EthicalAd addon ad placement injected"] =
 `<div
   class="raised"
   data-ea-campaign-types="community|paid"
@@ -21,9 +21,8 @@ snapshots["EthicalAd addon ad placement injected"] =
   data-ea-manual="true"
   data-ea-publisher="readthedocs"
   data-ea-type="text"
-  id="readthedocs-ea-text-footer"
+  id="readthedocs-ea-text-nostyle-nodoctool"
 >
 </div>
 `;
 /* end snapshot EthicalAd addon ad placement injected */
-

--- a/tests/ethicalads.test.html
+++ b/tests/ethicalads.test.html
@@ -63,12 +63,12 @@
           it("ad placement injected", async () => {
             const addon = new ethicalads.EthicalAdsAddon(config);
             const element = document.querySelector(
-              "#readthedocs-ea-text-footer",
+              "[id^=readthedocs-ea",
             );
 
             expect(element).to.exist;
-            expect(element).to.have.attribute("data-ea-type", "text");
-            expect(element).to.have.attribute(
+              expect(element).to.have.attribute("data-ea-type", "text");
+              expect(element).to.have.attribute(
               "data-ea-publisher",
               "readthedocs",
             );

--- a/tests/ethicalads.test.html
+++ b/tests/ethicalads.test.html
@@ -62,13 +62,11 @@
 
           it("ad placement injected", async () => {
             const addon = new ethicalads.EthicalAdsAddon(config);
-            const element = document.querySelector(
-              "[id^=readthedocs-ea",
-            );
+            const element = document.querySelector("[id^=readthedocs-ea");
 
             expect(element).to.exist;
-              expect(element).to.have.attribute("data-ea-type", "text");
-              expect(element).to.have.attribute(
+            expect(element).to.have.attribute("data-ea-type", "text");
+            expect(element).to.have.attribute(
               "data-ea-publisher",
               "readthedocs",
             );


### PR DESCRIPTION
This is a POC to show how we can use fixed footer ad on specific known themes. The logic is as follows:

- the theme has to be a known theme
- the image ad added to the navbar has to be below the fold
- show a fixed footer ad and we add some `padding-bottom` CSS style to the
  content container (theme-specific selector) with the height of the fixed
  footer ad (using fixed `47.2px` for now but it can be dynamically calculated)

The technique of adding the `padding-bottom` to a theme-specific element solves the problem highlighted in the previous approach done in https://github.com/readthedocs/addons/pull/447

### Sphinx Furo theme

[Peek 2025-07-07 12-59.webm](https://github.com/user-attachments/assets/62c455d5-3fbd-4e8c-b2b9-9e5f0987e502)


### Material for MkDocs

[Peek 2025-07-07 13-10.webm](https://github.com/user-attachments/assets/ec2cf1f1-47d3-4670-ae42-d8b4efcaa1e4)


Closes #616