### PR TITLE
Webpack: use filesystem cache to speed up boot time

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = (env, argv) => {
     // Use filesystem for cache instead memory (default) to be re-use the cache
     // between Docker container starts/stops. This speeds up boot time a lot.
     cache: {
-      type: "filesystem",
+      type: is_production ? "memory" : "filesystem",
     },
 
     optimization: {


### PR DESCRIPTION
Same as https://github.com/readthedocs/ext-theme/pull/643

It speeds up boot time by ~8x.