### PR TITLE
Fix: Hide flyout in print/PDF output

### DIFF
--- a/src/flyout.css
+++ b/src/flyout.css
@@ -176,3 +176,10 @@ small a {
   text-decoration: none;
   color: var(--readthedocs-flyout-link-color);
 }
+
+/* Hide flyout when printing or generating PDFs */
+@media print {
+  :host {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Description
Fixes the flyout menu overlapping documentation content when printing or generating PDFs.

## Problem
The `<readthedocs-flyout>` Shadow DOM component remains visible when printing documentation or saving as PDF, causing it to overlap and obscure the actual documentation content. This affects thousands of documentation sites hosted on Read the Docs.

## Solution
Added `@media print` CSS rule inside the Shadow DOM styles (`src/flyout.css`) to hide the flyout element when printing:

## Why This Approach
- **Shadow DOM Compatible**: Uses `:host` selector which correctly targets the Shadow DOM root
- **Print-Specific**: Only affects print/PDF output, not normal viewing
- **Clean**: No JavaScript required, pure CSS solution
- **Comprehensive**: Hides the entire component including all child elements

## Testing
- [x] Tested with dev server print preview
- [x] Verified PDF generation via browser
- [x] Confirmed no impact on normal page viewing
- [x] All tests pass (106/106)

## Screenshots
**Before:**
<img width="1920" height="1080" alt="Screenshot_20251122_191510" src="https://github.com/user-attachments/assets/fc6aa18c-3298-460d-b1ad-77de2e73a4d7" />

**After:**
<img width="1920" height="1080" alt="Screenshot_20251122_191056" src="https://github.com/user-attachments/assets/2ea29933-648e-413a-b447-cfde80dda778" />

