### PR TITLE
Add support for Zensical documentation tool

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@
 export const SPHINX = "sphinx";
 export const MKDOCS = "mkdocs";
 export const MKDOCS_MATERIAL = "mkdocs-material";
+export const ZENSICAL = "zensical";
 export const DOCUSAURUS = "docusaurus";
 export const PELICAN = "pelican";
 export const ASCIIDOCTOR = "asciidoctor";

--- a/src/defaults.css
+++ b/src/defaults.css
@@ -10,6 +10,11 @@
     --readthedocs-filetreediff-icon-width: 0.6rem;
   }
 
+  :root[data-readthedocs-tool="zensical"] {
+    --readthedocs-font-size: 1.455em;
+    --readthedocs-filetreediff-icon-width: 0.6rem;
+  }
+
   :root[data-readthedocs-tool="antora"] {
     --readthedocs-flyout-font-size: 0.7em;
     --readthedocs-notification-font-size: 0.75em;

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@ import {
   MDBOOK,
   MKDOCS,
   MKDOCS_MATERIAL,
+  ZENSICAL,
   DOCUSAURUS,
   PELICAN,
   ASCIIDOCTOR,
@@ -400,6 +401,7 @@ export class DocumentationTool {
     [ASCIIDOCTOR]: "div#content",
     [PELICAN]: "article",
     [DOCUSAURUS]: "article div.markdown",
+    [ZENSICAL]: "article",
     [ANTORA]: "article",
     [JEKYLL]: "article",
     [FALLBACK_DOCTOOL]: ["article", "main", "div.body", "div.document", "body"],
@@ -555,6 +557,10 @@ export class DocumentationTool {
 
     if (this.isDocusaurus()) {
       return DOCUSAURUS;
+    }
+
+    if (this.isZensical()) {
+      return ZENSICAL;
     }
 
     if (this.isAsciiDoctor()) {
@@ -715,6 +721,10 @@ export class DocumentationTool {
     return this.isDocusaurusTheme();
   }
 
+  isZensical() {
+    return this.isZensicalTheme();
+  }
+
   isPelican() {
     if (
       document.querySelectorAll('meta[name="generator"][content="Pelican"]')
@@ -833,6 +843,16 @@ export class DocumentationTool {
   isDocusaurusTheme() {
     if (
       document.querySelectorAll('meta[name="generator"][content*="Docusaurus"]')
+        .length === 1
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  isZensicalTheme() {
+    if (
+      document.querySelectorAll('meta[name="generator"][content*="zensical"]')
         .length === 1
     ) {
       return true;


### PR DESCRIPTION
Update some values to support Zensical properly. Note that dark mode detection is not supported -- they use a pretty custom pattern: `data-md-color-scheme="slate"` for dark mode and `data-md-color-scheme="default"`. We can talk more about that later.

### Search

<img width="904" height="400" alt="Screenshot_2025-11-26_10-54-18" src="https://github.com/user-attachments/assets/163fc175-3e2e-48fc-889c-8caabacb05b6" />

### Flyout

<img width="777" height="607" alt="Screenshot_2025-11-26_10-54-27" src="https://github.com/user-attachments/assets/aba1c44f-2673-4b6e-985e-61b1d925abd6" />

### Notification

<img width="847" height="204" alt="Screenshot_2025-11-26_10-54-33" src="https://github.com/user-attachments/assets/38d04cbd-734d-41f2-94ef-51fb555d7c87" />
