### PR TITLE
Docdiff: use the correct path to get the root selector option

### DIFF
--- a/src/docdiff.js
+++ b/src/docdiff.js
@@ -101,7 +101,7 @@ export class DocDiffElement extends LitElement {
     }
     this.config = config;
     this.rootSelector =
-      objectPath.get(this.config, "options.root_selector") ||
+      objectPath.get(this.config, "addons.options.root_selector") ||
       docTool.getRootSelector();
 
     // NOTE: maybe there is a better way to inject this styles?


### PR DESCRIPTION
I found this while debugging #661 since it was removing all the addons from the screen.