### PR TITLE
EA: always use `body` as selector to inject ad for fixed footer ads

### DIFF
--- a/src/ethicalads.js
+++ b/src/ethicalads.js
@@ -264,8 +264,8 @@ export class EthicalAdsAddon extends AddonBase {
         placement.getAttribute("data-ea-style") || "nostyle";
 
       // Always append the ad to the body when it's fixed footer.
-      // This avoid issues with z-index on parent elements.
-      if (placementStyle == "fixedfooter") {
+      // This avoids issues with z-index on parent elements.
+      if (placementStyle === "fixedfooter") {
         selector = "body";
       }
 


### PR DESCRIPTION
It solves issues with other elements in the page that were shown on top of the ad due to z-index problems.

Example of problems solved with this PR.

<img width="1241" height="558" alt="Screenshot_2025-12-09_18-57-07" src="https://github.com/user-attachments/assets/1159c229-ecb9-4edc-83ae-61ae5ba23cb3" />

<img width="698" height="403" alt="Screenshot_2025-12-10_09-53-30" src="https://github.com/user-attachments/assets/3a16ed7b-650d-4823-8481-6f0364a651fa" />
